### PR TITLE
Calculets api

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -4,7 +4,6 @@ const app = express();
 const calculets = require("./routes/calculets");
 const users = require("./routes/users");
 const records = require("./routes/records");
-const test = require("./routes/test");
 
 // middleware
 const { errorHandler } = require("./middleware/errorHandler");
@@ -33,6 +32,7 @@ if (process.env.NODE_ENV === "development") {
   const { swaggerUi, specs } = require("./swagger");
   app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
   // 테스트용 API
+  const test = require("./routes/test");
   app.use("/test", test);
 }
 

--- a/server/routes/calculets/index.js
+++ b/server/routes/calculets/index.js
@@ -47,6 +47,24 @@ router.get("/converters", errorHandler.dbWrapper(getCalculetList.converters));
 
 /**
  * @swagger
+ *  /api/calculets/recommendation:
+ *    get:
+ *      tags: [calculets]
+ *      summary: 추천계산기 목록 불러오기
+ *      description: (임시) 조회수 높은 top 15 계산기
+ *      responses:
+ *        200:
+ *          $ref: "#/components/responses/getRecommendationList"
+ *        400:
+ *          $ref: "#/components/responses/error"
+ */
+router.get(
+  "/recommendation",
+  errorHandler.dbWrapper(getCalculetList.recommendation)
+);
+
+/**
+ * @swagger
  *  /api/calculets/{calculetId}:
  *    get:
  *      tags: [calculets]

--- a/server/routes/calculets/index.js
+++ b/server/routes/calculets/index.js
@@ -65,6 +65,25 @@ router.get(
 
 /**
  * @swagger
+ *  /api/calculets/find:
+ *    get:
+ *      parameters:
+ *        - $ref: "#/components/parameters/mainId"
+ *        - $ref: "#/components/parameters/subId"
+ *        - $ref: "#/components/parameters/title"
+ *      tags: [calculets]
+ *      summary: 계산기 검색 (대분류 / 소분류 / 제목)
+ *      description: 대분류 | 소분류 | 계산기 제목으로 검색 필터 설정 가능 (모든 쿼리 파라미터는 필수X)
+ *      responses:
+ *        200:
+ *          $ref: "#/components/responses/getCalculetList"
+ *        400:
+ *          $ref: "#/components/responses/error"
+ */
+router.get("/find", errorHandler.dbWrapper(getCalculetList.search));
+
+/**
+ * @swagger
  *  /api/calculets/{calculetId}:
  *    get:
  *      tags: [calculets]

--- a/server/routes/calculets/index.js
+++ b/server/routes/calculets/index.js
@@ -71,6 +71,7 @@ router.get(
  *        - $ref: "#/components/parameters/mainId"
  *        - $ref: "#/components/parameters/subId"
  *        - $ref: "#/components/parameters/title"
+ *        - $ref: "#/components/parameters/limit"
  *      tags: [calculets]
  *      summary: 계산기 검색 (대분류 / 소분류 / 제목)
  *      description: 대분류 | 소분류 | 계산기 제목으로 검색 필터 설정 가능 (모든 쿼리 파라미터는 필수X)

--- a/server/swagger/calculets.yml
+++ b/server/swagger/calculets.yml
@@ -34,6 +34,13 @@ components:
       name: title
       schema:
         $ref: "#/components/schemas/calculet/properties/title"
+    limit:
+      in: query
+      required: false
+      name: limit
+      description: 최대 개수 - 미지정시 조건에 해당하는 모든 계산기 불러옴
+      schema:
+        type: integer
   responses:
     likeResult:
       content:

--- a/server/swagger/calculets.yml
+++ b/server/swagger/calculets.yml
@@ -16,6 +16,24 @@ components:
       name: calculetId
       schema:
         $ref: "#/components/schemas/calculetId"
+    mainId:
+      in: query
+      required: false
+      name: categoryMainId
+      schema:
+        $ref: "#/components/schemas/calculet/properties/categoryMainId"
+    subId:
+      in: query
+      required: false
+      name: categorySubId
+      schema:
+        $ref: "#/components/schemas/calculet/properties/categorySubId"
+    title:
+      in: query
+      required: false
+      name: title
+      schema:
+        $ref: "#/components/schemas/calculet/properties/title"
   responses:
     likeResult:
       content:
@@ -125,6 +143,7 @@ components:
         categorySubId:
           type: integer
           description: 카테고리 소분류
+          example: 1
     calculetId:
       type: string
       description: 계산기 UUID

--- a/server/swagger/calculets.yml
+++ b/server/swagger/calculets.yml
@@ -60,6 +60,14 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/calculetPreview"
+    getRecommendationList:
+      description: 추천 계산기 목록 (아래 스키마는 계산기 하나 미리보기)
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/calculetBanner"
     bookMarkList:
       description: 북마크 리스트
       content:
@@ -157,6 +165,17 @@ components:
           $ref: "#/components/schemas/calculet/properties/categorySubId"
         viewCnt:
           $ref: "#/components/schemas/statistics/properties/view"
+        contributor:
+          $ref: "#/components/schemas/userSimpleInfo"
+    calculetBanner:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/calculetId"
+        title:
+          $ref: "#/components/schemas/calculet/properties/title"
+        description:
+          $ref: "#/components/schemas/calculet/properties/description"
         contributor:
           $ref: "#/components/schemas/userSimpleInfo"
     updateLog:


### PR DESCRIPTION
### 📌 작업 내용
1. 추천 계산기 목록 api (현재는 추천 알고리즘 없는 관계로 조회수 많은 순으로 최대 15개)
2. 계산기 검색 api
    - 대분류id, 소분류id, 제목으로 쿼리 검색 가능
    - 검색창 api (제목)
    - 소분류 목록 페이지 api (대분류id, 소분류 id)

아직 페이지네이션 고려하진 않았습니다!

### 📌 변경 사항
새로 만든 검색 api 소분류 id에 0 넣어서 요청하면 기존 단위변환기 api로 사용 가능한데, 통일 할까요?

### ✅ Check List

- FE
  - [ ] warning 해결
  - [ ] console 주석
- BE
