### PR TITLE
[FIX] signup auth

### DIFF
--- a/server/routes/users/index.js
+++ b/server/routes/users/index.js
@@ -33,7 +33,7 @@ router.post(
   "/",
   [
     upload.single("profileImg"),
-    auth.validate,
+    auth.signUp,
     errorHandler.asyncWrapper(postProfile),
   ],
   errorHandler.dbWrapper(signUp)


### PR DESCRIPTION
### 📌 작업 내용
 회원가입 인증 로직 수정

### 📌 변경 사항
firebase custom claims는 업데이트 후에 새로 발급받은 토큰에만 적용이 됩니다.
따라서 회원가입이 끝나고 나면 토큰 새로 받아야 합니다. (아니면 401, code2 에러 뜸)

### ✅ Check List
- BE
  - [x] 새로운 api에 대한 에러 처리 (wrapper, 혹은 try-catch)
