### PR TITLE
[FIX] snake_case -> camelCase

### DIFF
--- a/server/models/init-models.js
+++ b/server/models/init-models.js
@@ -1,170 +1,170 @@
-const DataTypes = require("sequelize").DataTypes;
-const _admin = require("./tables/admin");
-const _calculetInfo = require("./tables/calculetInfo");
-const _calculetInfoTemp = require("./tables/calculetInfoTemp");
-const _calculetRecord = require("./tables/calculetRecord");
-const _calculetUpdateLog = require("./tables/calculetUpdateLog");
-const _category = require("./tables/category");
-const _categoryMain = require("./tables/categoryMain");
-const _categorySub = require("./tables/categorySub");
-const _userCalculetBookmark = require("./tables/userCalculetBookmark");
-const _userCalculetLike = require("./tables/userCalculetLike");
-const _userInfo = require("./tables/userInfo");
+var DataTypes = require("sequelize").DataTypes;
+var _admin = require("./tables/admin");
+var _calculetInfo = require("./tables/calculetInfo");
+var _calculetInfoTemp = require("./tables/calculetInfoTemp");
+var _calculetRecord = require("./tables/calculetRecord");
+var _calculetUpdateLog = require("./tables/calculetUpdateLog");
+var _category = require("./tables/category");
+var _categoryMain = require("./tables/categoryMain");
+var _categorySub = require("./tables/categorySub");
+var _userCalculetBookmark = require("./tables/userCalculetBookmark");
+var _userCalculetLike = require("./tables/userCalculetLike");
+var _userInfo = require("./tables/userInfo");
 
 function initModels(sequelize) {
-  const admin = _admin(sequelize, DataTypes);
-  const calculetInfo = _calculetInfo(sequelize, DataTypes);
-  const calculetInfoTemp = _calculetInfoTemp(sequelize, DataTypes);
-  const calculetRecord = _calculetRecord(sequelize, DataTypes);
-  const calculetUpdateLog = _calculetUpdateLog(sequelize, DataTypes);
-  const category = _category(sequelize, DataTypes);
-  const categoryMain = _categoryMain(sequelize, DataTypes);
-  const categorySub = _categorySub(sequelize, DataTypes);
-  const userCalculetBookmark = _userCalculetBookmark(sequelize, DataTypes);
-  const userCalculetLike = _userCalculetLike(sequelize, DataTypes);
-  const userInfo = _userInfo(sequelize, DataTypes);
+  var admin = _admin(sequelize, DataTypes);
+  var calculetInfo = _calculetInfo(sequelize, DataTypes);
+  var calculetInfoTemp = _calculetInfoTemp(sequelize, DataTypes);
+  var calculetRecord = _calculetRecord(sequelize, DataTypes);
+  var calculetUpdateLog = _calculetUpdateLog(sequelize, DataTypes);
+  var category = _category(sequelize, DataTypes);
+  var categoryMain = _categoryMain(sequelize, DataTypes);
+  var categorySub = _categorySub(sequelize, DataTypes);
+  var userCalculetBookmark = _userCalculetBookmark(sequelize, DataTypes);
+  var userCalculetLike = _userCalculetLike(sequelize, DataTypes);
+  var userInfo = _userInfo(sequelize, DataTypes);
 
   calculetInfo.belongsToMany(userInfo, {
-    as: "user_id_user_infos",
+    as: "userIdUserInfos",
     through: userCalculetBookmark,
-    foreignKey: "calculet_id",
-    otherKey: "user_id",
+    foreignKey: "calculetId",
+    otherKey: "userId",
   });
   calculetInfo.belongsToMany(userInfo, {
-    as: "user_id_user_info_user_calculet_likes",
+    as: "userIdUserInfoUserCalculetLikes",
     through: userCalculetLike,
-    foreignKey: "calculet_id",
-    otherKey: "user_id",
+    foreignKey: "calculetId",
+    otherKey: "userId",
   });
   categoryMain.belongsToMany(categorySub, {
-    as: "sub_id_category_subs",
+    as: "subIdCategorySubs",
     through: category,
-    foreignKey: "main_id",
-    otherKey: "sub_id",
+    foreignKey: "mainId",
+    otherKey: "subId",
   });
   categorySub.belongsToMany(categoryMain, {
-    as: "main_id_category_mains",
+    as: "mainIdCategoryMains",
     through: category,
-    foreignKey: "sub_id",
-    otherKey: "main_id",
+    foreignKey: "subId",
+    otherKey: "mainId",
   });
   userInfo.belongsToMany(calculetInfo, {
-    as: "calculet_id_calculet_infos",
+    as: "calculetIdCalculetInfos",
     through: userCalculetBookmark,
-    foreignKey: "user_id",
-    otherKey: "calculet_id",
+    foreignKey: "userId",
+    otherKey: "calculetId",
   });
   userInfo.belongsToMany(calculetInfo, {
-    as: "calculet_id_calculet_info_user_calculet_likes",
+    as: "calculetIdCalculetInfoUserCalculetLikes",
     through: userCalculetLike,
-    foreignKey: "user_id",
-    otherKey: "calculet_id",
+    foreignKey: "userId",
+    otherKey: "calculetId",
   });
   calculetRecord.belongsTo(calculetInfo, {
     as: "calculet",
-    foreignKey: "calculet_id",
+    foreignKey: "calculetId",
   });
   calculetInfo.hasMany(calculetRecord, {
-    as: "calculet_records",
-    foreignKey: "calculet_id",
+    as: "calculetRecords",
+    foreignKey: "calculetId",
   });
   calculetUpdateLog.belongsTo(calculetInfo, {
     as: "calculet",
-    foreignKey: "calculet_id",
+    foreignKey: "calculetId",
   });
   calculetInfo.hasMany(calculetUpdateLog, {
-    as: "calculet_update_logs",
-    foreignKey: "calculet_id",
+    as: "calculetUpdateLogs",
+    foreignKey: "calculetId",
   });
   userCalculetBookmark.belongsTo(calculetInfo, {
     as: "calculet",
-    foreignKey: "calculet_id",
+    foreignKey: "calculetId",
   });
   calculetInfo.hasMany(userCalculetBookmark, {
-    as: "user_calculet_bookmarks",
-    foreignKey: "calculet_id",
+    as: "userCalculetBookmarks",
+    foreignKey: "calculetId",
   });
   userCalculetLike.belongsTo(calculetInfo, {
     as: "calculet",
-    foreignKey: "calculet_id",
+    foreignKey: "calculetId",
   });
   calculetInfo.hasMany(userCalculetLike, {
-    as: "user_calculet_likes",
-    foreignKey: "calculet_id",
+    as: "userCalculetLikes",
+    foreignKey: "calculetId",
   });
   calculetInfo.belongsTo(category, {
-    as: "category_main",
-    foreignKey: "category_main_id",
+    as: "categoryMain",
+    foreignKey: "categoryMainId",
   });
   category.hasMany(calculetInfo, {
-    as: "calculet_infos",
-    foreignKey: "category_main_id",
+    as: "calculetInfos",
+    foreignKey: "categoryMainId",
   });
   calculetInfo.belongsTo(category, {
-    as: "category_sub",
-    foreignKey: "category_sub_id",
+    as: "categorySub",
+    foreignKey: "categorySubId",
   });
   category.hasMany(calculetInfo, {
-    as: "category_sub_calculet_infos",
-    foreignKey: "category_sub_id",
+    as: "categorySubCalculetInfos",
+    foreignKey: "categorySubId",
   });
   calculetInfoTemp.belongsTo(category, {
-    as: "category_main",
-    foreignKey: "category_main_id",
+    as: "categoryMain",
+    foreignKey: "categoryMainId",
   });
   category.hasMany(calculetInfoTemp, {
-    as: "calculet_info_temps",
-    foreignKey: "category_main_id",
+    as: "calculetInfoTemps",
+    foreignKey: "categoryMainId",
   });
   calculetInfoTemp.belongsTo(category, {
-    as: "category_sub",
-    foreignKey: "category_sub_id",
+    as: "categorySub",
+    foreignKey: "categorySubId",
   });
   category.hasMany(calculetInfoTemp, {
-    as: "category_sub_calculet_info_temps",
-    foreignKey: "category_sub_id",
+    as: "categorySubCalculetInfoTemps",
+    foreignKey: "categorySubId",
   });
-  category.belongsTo(categoryMain, { as: "main", foreignKey: "main_id" });
-  categoryMain.hasMany(category, { as: "categories", foreignKey: "main_id" });
-  category.belongsTo(categorySub, { as: "sub", foreignKey: "sub_id" });
-  categorySub.hasMany(category, { as: "categories", foreignKey: "sub_id" });
-  admin.belongsTo(userInfo, { as: "id_user_info", foreignKey: "id" });
+  category.belongsTo(categoryMain, { as: "main", foreignKey: "mainId" });
+  categoryMain.hasMany(category, { as: "categories", foreignKey: "mainId" });
+  category.belongsTo(categorySub, { as: "sub", foreignKey: "subId" });
+  categorySub.hasMany(category, { as: "categories", foreignKey: "subId" });
+  admin.belongsTo(userInfo, { as: "idUserInfo", foreignKey: "id" });
   userInfo.hasOne(admin, { as: "admin", foreignKey: "id" });
-  admin.belongsTo(userInfo, { as: "email_user_info", foreignKey: "email" });
-  userInfo.hasMany(admin, { as: "email_admins", foreignKey: "email" });
+  admin.belongsTo(userInfo, { as: "emailUserInfo", foreignKey: "email" });
+  userInfo.hasMany(admin, { as: "emailAdmins", foreignKey: "email" });
   calculetInfo.belongsTo(userInfo, {
     as: "contributor",
-    foreignKey: "contributor_id",
+    foreignKey: "contributorId",
   });
   userInfo.hasMany(calculetInfo, {
-    as: "calculet_infos",
-    foreignKey: "contributor_id",
+    as: "calculetInfos",
+    foreignKey: "contributorId",
   });
   calculetInfoTemp.belongsTo(userInfo, {
     as: "contributor",
-    foreignKey: "contributor_id",
+    foreignKey: "contributorId",
   });
   userInfo.hasMany(calculetInfoTemp, {
-    as: "calculet_info_temps",
-    foreignKey: "contributor_id",
+    as: "calculetInfoTemps",
+    foreignKey: "contributorId",
   });
-  calculetRecord.belongsTo(userInfo, { as: "user", foreignKey: "user_id" });
+  calculetRecord.belongsTo(userInfo, { as: "user", foreignKey: "userId" });
   userInfo.hasMany(calculetRecord, {
-    as: "calculet_records",
-    foreignKey: "user_id",
+    as: "calculetRecords",
+    foreignKey: "userId",
   });
   userCalculetBookmark.belongsTo(userInfo, {
     as: "user",
-    foreignKey: "user_id",
+    foreignKey: "userId",
   });
   userInfo.hasMany(userCalculetBookmark, {
-    as: "user_calculet_bookmarks",
-    foreignKey: "user_id",
+    as: "userCalculetBookmarks",
+    foreignKey: "userId",
   });
-  userCalculetLike.belongsTo(userInfo, { as: "user", foreignKey: "user_id" });
+  userCalculetLike.belongsTo(userInfo, { as: "user", foreignKey: "userId" });
   userInfo.hasMany(userCalculetLike, {
-    as: "user_calculet_likes",
-    foreignKey: "user_id",
+    as: "userCalculetLikes",
+    foreignKey: "userId",
   });
 
   return {

--- a/server/models/init-models.js
+++ b/server/models/init-models.js
@@ -1,28 +1,28 @@
-var DataTypes = require("sequelize").DataTypes;
-var _admin = require("./tables/admin");
-var _calculetInfo = require("./tables/calculetInfo");
-var _calculetInfoTemp = require("./tables/calculetInfoTemp");
-var _calculetRecord = require("./tables/calculetRecord");
-var _calculetUpdateLog = require("./tables/calculetUpdateLog");
-var _category = require("./tables/category");
-var _categoryMain = require("./tables/categoryMain");
-var _categorySub = require("./tables/categorySub");
-var _userCalculetBookmark = require("./tables/userCalculetBookmark");
-var _userCalculetLike = require("./tables/userCalculetLike");
-var _userInfo = require("./tables/userInfo");
+const DataTypes = require("sequelize").DataTypes;
+const _admin = require("./tables/admin");
+const _calculetInfo = require("./tables/calculetInfo");
+const _calculetInfoTemp = require("./tables/calculetInfoTemp");
+const _calculetRecord = require("./tables/calculetRecord");
+const _calculetUpdateLog = require("./tables/calculetUpdateLog");
+const _category = require("./tables/category");
+const _categoryMain = require("./tables/categoryMain");
+const _categorySub = require("./tables/categorySub");
+const _userCalculetBookmark = require("./tables/userCalculetBookmark");
+const _userCalculetLike = require("./tables/userCalculetLike");
+const _userInfo = require("./tables/userInfo");
 
 function initModels(sequelize) {
-  var admin = _admin(sequelize, DataTypes);
-  var calculetInfo = _calculetInfo(sequelize, DataTypes);
-  var calculetInfoTemp = _calculetInfoTemp(sequelize, DataTypes);
-  var calculetRecord = _calculetRecord(sequelize, DataTypes);
-  var calculetUpdateLog = _calculetUpdateLog(sequelize, DataTypes);
-  var category = _category(sequelize, DataTypes);
-  var categoryMain = _categoryMain(sequelize, DataTypes);
-  var categorySub = _categorySub(sequelize, DataTypes);
-  var userCalculetBookmark = _userCalculetBookmark(sequelize, DataTypes);
-  var userCalculetLike = _userCalculetLike(sequelize, DataTypes);
-  var userInfo = _userInfo(sequelize, DataTypes);
+  const admin = _admin(sequelize, DataTypes);
+  const calculetInfo = _calculetInfo(sequelize, DataTypes);
+  const calculetInfoTemp = _calculetInfoTemp(sequelize, DataTypes);
+  const calculetRecord = _calculetRecord(sequelize, DataTypes);
+  const calculetUpdateLog = _calculetUpdateLog(sequelize, DataTypes);
+  const category = _category(sequelize, DataTypes);
+  const categoryMain = _categoryMain(sequelize, DataTypes);
+  const categorySub = _categorySub(sequelize, DataTypes);
+  const userCalculetBookmark = _userCalculetBookmark(sequelize, DataTypes);
+  const userCalculetLike = _userCalculetLike(sequelize, DataTypes);
+  const userInfo = _userInfo(sequelize, DataTypes);
 
   calculetInfo.belongsToMany(userInfo, {
     as: "userIdUserInfos",

--- a/server/models/tables/admin.js
+++ b/server/models/tables/admin.js
@@ -1,56 +1,53 @@
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('admin', {
-    id: {
-      type: DataTypes.STRING(36),
-      allowNull: false,
-      primaryKey: true,
-      references: {
-        model: 'user_info',
-        key: 'id'
-      }
+  return sequelize.define(
+    "admin",
+    {
+      id: {
+        type: DataTypes.STRING(36),
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "user_info",
+          key: "id",
+        },
+      },
+      email: {
+        type: DataTypes.STRING(254),
+        allowNull: false,
+        references: {
+          model: "user_info",
+          key: "email",
+        },
+      },
+      accessLevel: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        field: "access_level",
+      },
     },
-    email: {
-      type: DataTypes.STRING(254),
-      allowNull: false,
-      references: {
-        model: 'user_info',
-        key: 'email'
-      }
-    },
-    accessLevel: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      field: "access_level"
+    {
+      sequelize,
+      tableName: "admin",
+      timestamps: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "admin_ibfk_1_idx",
+          using: "BTREE",
+          fields: [{ name: "id" }, { name: "email" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'admin',
-    timestamps: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "admin_ibfk_1_idx",
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-          { name: "email" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/calculetInfo.js
+++ b/server/models/tables/calculetInfo.js
@@ -1,168 +1,158 @@
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('calculetInfo', {
-    id: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      primaryKey: true
-    },
-    title: {
-      type: DataTypes.STRING(100),
-      allowNull: false
-    },
-    srcCode: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: "src_code"
-    },
-    manual: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
-    description: {
-      type: DataTypes.STRING(100),
-      allowNull: false
-    },
-    categoryMainId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'category',
-        key: 'main_id'
+  return sequelize.define(
+    "calculetInfo",
+    {
+      id: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        primaryKey: true,
       },
-      field: "category_main_id"
-    },
-    categorySubId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'category',
-        key: 'sub_id'
+      title: {
+        type: DataTypes.STRING(100),
+        allowNull: false,
       },
-      field: "category_sub_id"
-    },
-    contributorId: {
-      type: DataTypes.STRING(36),
-      allowNull: true,
-      references: {
-        model: 'user_info',
-        key: 'id'
+      srcCode: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+        field: "src_code",
       },
-      field: "contributor_id"
+      manual: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      description: {
+        type: DataTypes.STRING(100),
+        allowNull: false,
+      },
+      categoryMainId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: "category",
+          key: "main_id",
+        },
+        field: "category_main_id",
+      },
+      categorySubId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: "category",
+          key: "sub_id",
+        },
+        field: "category_sub_id",
+      },
+      contributorId: {
+        type: DataTypes.STRING(36),
+        allowNull: true,
+        references: {
+          model: "user_info",
+          key: "id",
+        },
+        field: "contributor_id",
+      },
+      blocked: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      viewCnt: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        defaultValue: 0,
+        field: "view_cnt",
+      },
+      calculationCnt: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        defaultValue: 0,
+        field: "calculation_cnt",
+      },
+      userCnt: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        defaultValue: 0,
+        field: "user_cnt",
+      },
+      likeCnt: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        defaultValue: 0,
+        field: "like_cnt",
+      },
+      bookmarkCnt: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        defaultValue: 0,
+        field: "bookmark_cnt",
+      },
+      reportCnt: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        defaultValue: 0,
+        field: "report_cnt",
+      },
+      statistics: {
+        type: DataTypes.VIRTUAL,
+        get() {
+          return {
+            bookmark: this.bookmarkCnt,
+            like: this.likeCnt,
+            report: this.reportCnt,
+            view: this.viewCnt,
+            user: this.userCnt,
+            calculation: this.calculationCnt,
+          };
+        },
+      },
     },
-    blocked: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: 0
-    },
-    viewCnt: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      defaultValue: 0,
-      field: "view_cnt"
-    },
-    calculationCnt: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      defaultValue: 0,
-      field: "calculation_cnt"
-    },
-    userCnt: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      defaultValue: 0,
-      field: "user_cnt"
-    },
-    likeCnt: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      defaultValue: 0,
-      field: "like_cnt"
-    },
-    bookmarkCnt: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      defaultValue: 0,
-      field: "bookmark_cnt"
-    },
-    reportCnt: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      defaultValue: 0,
-      field: "report_cnt"
-    },
-    statistics: {
-      type: DataTypes.VIRTUAL,
-      get() {
-        return {
-          bookmark: this.bookmarkCnt,
-          like: this.likeCnt,
-          report: this.reportCnt,
-          view: this.viewCnt,
-          user: this.userCnt,
-          calculation: this.calculationCnt,
-        };
-      }
+    {
+      sequelize,
+      tableName: "calculet_info",
+      timestamps: true,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "calculet_info_ibfk_1_idx",
+          using: "BTREE",
+          fields: [{ name: "contributor_id" }],
+        },
+        {
+          name: "calculet_info_ibfk_2_idx",
+          using: "BTREE",
+          fields: [{ name: "category_main_id" }, { name: "category_sub_id" }],
+        },
+        {
+          name: "desc_FULLTEXT",
+          type: "FULLTEXT",
+          fields: [{ name: "description" }, { name: "manual" }],
+        },
+        {
+          name: "title_desc_FULLTEXT",
+          type: "FULLTEXT",
+          fields: [
+            { name: "title" },
+            { name: "description" },
+            { name: "manual" },
+          ],
+        },
+        {
+          name: "title_FULLTEXT",
+          type: "FULLTEXT",
+          fields: [{ name: "title" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: "calculet_info",
-    timestamps: true,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "calculet_info_ibfk_1_idx",
-        using: "BTREE",
-        fields: [
-          { name: "contributor_id" },
-        ]
-      },
-      {
-        name: "calculet_info_ibfk_2_idx",
-        using: "BTREE",
-        fields: [
-          { name: "category_main_id" },
-          { name: "category_sub_id" },
-        ]
-      },
-      {
-        name: "title_FULLTEXT",
-        type: "FULLTEXT",
-        fields: [
-          { name: "title" },
-        ]
-      },
-      {
-        name: "desc_FULLTEXT",
-        type: "FULLTEXT",
-        fields: [
-          { name: "description" },
-          { name: "manual" },
-        ]
-      },
-      {
-        name: "title_desc_FULLTEXT",
-        type: "FULLTEXT",
-        fields: [
-          { name: "title" },
-          { name: "description" },
-          { name: "manual" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/calculetInfoTemp.js
+++ b/server/models/tables/calculetInfoTemp.js
@@ -1,98 +1,93 @@
-const Sequelize = require('sequelize');
+const Sequelize = require("sequelize");
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('calculetInfoTemp', {
-    id: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      primaryKey: true,
-      defaultValue: Sequelize.Sequelize.fn("uuid")
-    },
-    title: {
-      type: DataTypes.STRING(100),
-      allowNull: false
-    },
-    srcCode: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      field: "src_code"
-    },
-    manual: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
-    description: {
-      type: DataTypes.STRING(100),
-      allowNull: false
-    },
-    categoryMainId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'category',
-        key: 'main_id'
+  return sequelize.define(
+    "calculetInfoTemp",
+    {
+      id: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.Sequelize.fn("uuid"),
       },
-      field: "category_main_id"
-    },
-    categorySubId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'category',
-        key: 'sub_id'
+      title: {
+        type: DataTypes.STRING(100),
+        allowNull: false,
       },
-      field: "category_sub_id"
-    },
-    contributorId: {
-      type: DataTypes.STRING(36),
-      allowNull: true,
-      references: {
-        model: 'user_info',
-        key: 'id'
+      srcCode: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+        field: "src_code",
       },
-      field: "contributor_id"
+      manual: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      description: {
+        type: DataTypes.STRING(100),
+        allowNull: false,
+      },
+      categoryMainId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: "category",
+          key: "main_id",
+        },
+        field: "category_main_id",
+      },
+      categorySubId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: "category",
+          key: "sub_id",
+        },
+        field: "category_sub_id",
+      },
+      contributorId: {
+        type: DataTypes.STRING(36),
+        allowNull: true,
+        references: {
+          model: "user_info",
+          key: "id",
+        },
+        field: "contributor_id",
+      },
+      registered: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: 0,
+      },
     },
-    registered: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: 0
+    {
+      sequelize,
+      tableName: "calculet_info_temp",
+      hasTrigger: true,
+      timestamps: true,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "calculet_info_temp_ibfk_1_idx",
+          using: "BTREE",
+          fields: [{ name: "contributor_id" }],
+        },
+        {
+          name: "calculet_info_temp_ibfk_2_idx",
+          using: "BTREE",
+          fields: [{ name: "category_main_id" }, { name: "category_sub_id" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'calculet_info_temp',
-    hasTrigger: true,
-    timestamps: true,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "calculet_info_temp_ibfk_1_idx",
-        using: "BTREE",
-        fields: [
-          { name: "contributor_id" },
-        ]
-      },
-      {
-        name: "calculet_info_temp_ibfk_2_idx",
-        using: "BTREE",
-        fields: [
-          { name: "category_main_id" },
-          { name: "category_sub_id" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/calculetRecord.js
+++ b/server/models/tables/calculetRecord.js
@@ -1,75 +1,71 @@
-const Sequelize = require('sequelize');
+const Sequelize = require("sequelize");
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('calculetRecord', {
-    id: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      primaryKey: true,
-      defaultValue: Sequelize.Sequelize.fn("uuid")
-    },
-    calculetId: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      references: {
-        model: 'calculet_info',
-        key: 'id'
+  return sequelize.define(
+    "calculetRecord",
+    {
+      id: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.Sequelize.fn("uuid"),
       },
-      field: "calculet_id"
-    },
-    userId: {
-      type: DataTypes.STRING(36),
-      allowNull: false,
-      references: {
-        model: 'user_info',
-        key: 'id'
+      calculetId: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        references: {
+          model: "calculet_info",
+          key: "id",
+        },
+        field: "calculet_id",
       },
-      field: "user_id"
+      userId: {
+        type: DataTypes.STRING(36),
+        allowNull: false,
+        references: {
+          model: "user_info",
+          key: "id",
+        },
+        field: "user_id",
+      },
+      input: {
+        type: DataTypes.STRING(2184),
+        allowNull: true,
+      },
+      output: {
+        type: DataTypes.STRING(2184),
+        allowNull: false,
+      },
     },
-    input: {
-      type: DataTypes.STRING(2184),
-      allowNull: true
-    },
-    output: {
-      type: DataTypes.STRING(2184),
-      allowNull: false
+    {
+      sequelize,
+      tableName: "calculet_record",
+      hasTrigger: true,
+      timestamps: true,
+      updatedAt: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "calculet_record_ibfk_1_idx",
+          using: "BTREE",
+          fields: [{ name: "calculet_id" }],
+        },
+        {
+          name: "calculet_record_ibfk_2_idx",
+          using: "BTREE",
+          fields: [{ name: "user_id" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'calculet_record',
-    hasTrigger: true,
-    timestamps: true,
-    updatedAt: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "calculet_record_ibfk_1_idx",
-        using: "BTREE",
-        fields: [
-          { name: "calculet_id" },
-        ]
-      },
-      {
-        name: "calculet_record_ibfk_2_idx",
-        using: "BTREE",
-        fields: [
-          { name: "user_id" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/calculetUpdateLog.js
+++ b/server/models/tables/calculetUpdateLog.js
@@ -1,63 +1,59 @@
-const Sequelize = require('sequelize');
+const Sequelize = require("sequelize");
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('calculetUpdateLog', {
-    id: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      primaryKey: true,
-      defaultValue: Sequelize.Sequelize.fn("uuid")
-    },
-    message: {
-      type: DataTypes.STRING(100),
-      allowNull: false
-    },
-    calculetId: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      references: {
-        model: 'calculet_info',
-        key: 'id'
+  return sequelize.define(
+    "calculetUpdateLog",
+    {
+      id: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.Sequelize.fn("uuid"),
       },
-      field: "calculet_id"
+      message: {
+        type: DataTypes.STRING(100),
+        allowNull: false,
+      },
+      calculetId: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        references: {
+          model: "calculet_info",
+          key: "id",
+        },
+        field: "calculet_id",
+      },
+    },
+    {
+      sequelize,
+      tableName: "calculet_update_log",
+      hasTrigger: true,
+      timestamps: true,
+      updatedAt: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "calculet_update_log_ibfk_1_idx",
+          using: "BTREE",
+          fields: [{ name: "calculet_id" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'calculet_update_log',
-    hasTrigger: true,
-    timestamps: true,
-    updatedAt: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "calculet_update_log_ibfk_1_idx",
-        using: "BTREE",
-        fields: [
-          { name: "calculet_id" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/category.js
+++ b/server/models/tables/category.js
@@ -1,46 +1,45 @@
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('category', {
-    mainId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      primaryKey: true,
-      references: {
-        model: 'category_main',
-        key: 'id'
+  return sequelize.define(
+    "category",
+    {
+      mainId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "category_main",
+          key: "id",
+        },
+        field: "main_id",
       },
-      field: "main_id"
+      subId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "category_sub",
+          key: "id",
+        },
+        field: "sub_id",
+      },
     },
-    subId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      primaryKey: true,
-      references: {
-        model: 'category_sub',
-        key: 'id'
-      },
-      field: "sub_id"
+    {
+      sequelize,
+      tableName: "category",
+      timestamps: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "main_id" }, { name: "sub_id" }],
+        },
+        {
+          name: "category_ibfk_2_idx",
+          using: "BTREE",
+          fields: [{ name: "sub_id" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'category',
-    timestamps: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "main_id" },
-          { name: "sub_id" },
-        ]
-      },
-      {
-        name: "category_ibfk_2_idx",
-        using: "BTREE",
-        fields: [
-          { name: "sub_id" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/categoryMain.js
+++ b/server/models/tables/categoryMain.js
@@ -1,44 +1,42 @@
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('categoryMain', {
-    id: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      primaryKey: true
+  return sequelize.define(
+    "categoryMain",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        unique: "name_UNIQUE",
+      },
     },
-    name: {
-      type: DataTypes.STRING(20),
-      allowNull: false,
-      unique: "name_UNIQUE"
+    {
+      sequelize,
+      tableName: "category_main",
+      timestamps: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "name_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "name" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'category_main',
-    timestamps: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "name_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "name" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/categorySub.js
+++ b/server/models/tables/categorySub.js
@@ -1,44 +1,42 @@
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('categorySub', {
-    id: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      primaryKey: true
+  return sequelize.define(
+    "categorySub",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        unique: "name_UNIQUE",
+      },
     },
-    name: {
-      type: DataTypes.STRING(20),
-      allowNull: false,
-      unique: "name_UNIQUE"
+    {
+      sequelize,
+      tableName: "category_sub",
+      timestamps: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "name_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "name" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'category_sub',
-    timestamps: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "name_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "name" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/userCalculetBookmark.js
+++ b/server/models/tables/userCalculetBookmark.js
@@ -1,46 +1,45 @@
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('userCalculetBookmark', {
-    calculetId: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      primaryKey: true,
-      references: {
-        model: 'calculet_info',
-        key: 'id'
+  return sequelize.define(
+    "userCalculetBookmark",
+    {
+      calculetId: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "calculet_info",
+          key: "id",
+        },
+        field: "calculet_id",
       },
-      field: "calculet_id"
+      userId: {
+        type: DataTypes.STRING(36),
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "user_info",
+          key: "id",
+        },
+        field: "user_id",
+      },
     },
-    userId: {
-      type: DataTypes.STRING(36),
-      allowNull: false,
-      primaryKey: true,
-      references: {
-        model: 'user_info',
-        key: 'id'
-      },
-      field: "user_id"
+    {
+      sequelize,
+      tableName: "user_calculet_bookmark",
+      timestamps: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "calculet_id" }, { name: "user_id" }],
+        },
+        {
+          name: "user_calculet_like_ibfk_2_idx",
+          using: "BTREE",
+          fields: [{ name: "user_id" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'user_calculet_bookmark',
-    timestamps: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "calculet_id" },
-          { name: "user_id" },
-        ]
-      },
-      {
-        name: "user_calculet_like_ibfk_2_idx",
-        using: "BTREE",
-        fields: [
-          { name: "user_id" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/userCalculetLike.js
+++ b/server/models/tables/userCalculetLike.js
@@ -1,46 +1,45 @@
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('userCalculetLike', {
-    calculetId: {
-      type: DataTypes.CHAR(36),
-      allowNull: false,
-      primaryKey: true,
-      references: {
-        model: 'calculet_info',
-        key: 'id'
+  return sequelize.define(
+    "userCalculetLike",
+    {
+      calculetId: {
+        type: DataTypes.CHAR(36),
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "calculet_info",
+          key: "id",
+        },
+        field: "calculet_id",
       },
-      field: "calculet_id"
+      userId: {
+        type: DataTypes.STRING(36),
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: "user_info",
+          key: "id",
+        },
+        field: "user_id",
+      },
     },
-    userId: {
-      type: DataTypes.STRING(36),
-      allowNull: false,
-      primaryKey: true,
-      references: {
-        model: 'user_info',
-        key: 'id'
-      },
-      field: "user_id"
+    {
+      sequelize,
+      tableName: "user_calculet_like",
+      timestamps: false,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "calculet_id" }, { name: "user_id" }],
+        },
+        {
+          name: "user_calculet_like_ibfk_2_idx",
+          using: "BTREE",
+          fields: [{ name: "user_id" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'user_calculet_like',
-    timestamps: false,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "calculet_id" },
-          { name: "user_id" },
-        ]
-      },
-      {
-        name: "user_calculet_like_ibfk_2_idx",
-        using: "BTREE",
-        fields: [
-          { name: "user_id" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/models/tables/userInfo.js
+++ b/server/models/tables/userInfo.js
@@ -1,83 +1,78 @@
 const { urlFormatter } = require("../../utils/urlFormatter");
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('userInfo', {
-    id: {
-      type: DataTypes.STRING(36),
-      allowNull: false,
-      primaryKey: true
+  return sequelize.define(
+    "userInfo",
+    {
+      id: {
+        type: DataTypes.STRING(36),
+        allowNull: false,
+        primaryKey: true,
+      },
+      email: {
+        type: DataTypes.STRING(254),
+        allowNull: false,
+      },
+      userName: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        field: "user_name",
+      },
+      profileImgSrc: {
+        type: DataTypes.CHAR(36),
+        allowNull: true,
+        unique: true,
+        field: "profile_img",
+        get() {
+          const rawValue = this.getDataValue("profileImgSrc");
+          return rawValue ? urlFormatter("profileImg", rawValue) : null;
+        },
+      },
+      bio: {
+        type: DataTypes.STRING(200),
+        allowNull: true,
+      },
+      sex: {
+        type: DataTypes.CHAR(1),
+        allowNull: false,
+      },
+      birthdate: {
+        type: DataTypes.DATEONLY,
+        allowNull: false,
+      },
+      job: {
+        type: DataTypes.STRING(25),
+        allowNull: false,
+      },
     },
-    email: {
-      type: DataTypes.STRING(254),
-      allowNull: false
-    },
-    userName: {
-      type: DataTypes.STRING(20),
-      allowNull: false,
-      field: "user_name"
-    },
-    profileImgSrc: {
-      type: DataTypes.CHAR(36),
-      allowNull: true,
-      unique: true,
-      field: "profile_img",
-      get() {
-        const rawValue = this.getDataValue("profileImgSrc");
-        return rawValue ? urlFormatter("profileImg", rawValue) : null;
-      }
-    },
-    bio: {
-      type: DataTypes.STRING(200),
-      allowNull: true
-    },
-    sex: {
-      type: DataTypes.CHAR(1),
-      allowNull: false
-    },
-    birthdate: {
-      type: DataTypes.DATEONLY,
-      allowNull: false
-    },
-    job: {
-      type: DataTypes.STRING(25),
-      allowNull: false
+    {
+      sequelize,
+      tableName: "user_info",
+      timestamps: true,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "id_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "id" }],
+        },
+        {
+          name: "profile_img_UNIQUE",
+          unique: true,
+          using: "BTREE",
+          fields: [{ name: "profile_img" }],
+        },
+        {
+          name: "id_email",
+          using: "BTREE",
+          fields: [{ name: "id" }, { name: "email" }],
+        },
+      ],
     }
-  }, {
-    sequelize,
-    tableName: 'user_info',
-    timestamps: true,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "id_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "profile_img_UNIQUE",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "profile_img" },
-        ]
-      },
-      {
-        name: "id_email",
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-          { name: "email" },
-        ]
-      },
-    ]
-  });
+  );
 };

--- a/server/orm.js
+++ b/server/orm.js
@@ -11,6 +11,7 @@ const auto = new SequelizeAuto(
     directory: "./models/",
     caseModel: "c",
     caseFile: "c",
+    caseProp: "c",
   }
 );
 auto.run((err) => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,7 @@
         "multer": "^1.4.5-lts.1",
         "mysql2": "^2.3.3",
         "nodemailer": "^6.9.1",
-        "sequelize": "^6.26.0",
+        "sequelize": "^6.31.0",
         "tslib": "^2.5.0",
         "uuid": "^9.0.0"
       },
@@ -9594,9 +9594,9 @@
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/sequelize": {
-      "version": "6.29.3",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.3.tgz",
-      "integrity": "sha512-iLbrN//Eh18zXIlNEUNQx7lk5R+SF39m+66bnrT3x8WB8sbxMH2hF4vw8RIa9ZzB1+c94rclMv/i8fngXmb/4A==",
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.31.0.tgz",
+      "integrity": "sha512-nCPVtv+QydBmb3Us2jCNAr1Dx3gST83VZxxrUQn/JAVFCOrmYOgUaPUz5bevummyNf30zfHsZhIKYAOD3ULfTA==",
       "funding": [
         {
           "type": "opencollective",
@@ -18052,9 +18052,9 @@
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "sequelize": {
-      "version": "6.29.3",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.3.tgz",
-      "integrity": "sha512-iLbrN//Eh18zXIlNEUNQx7lk5R+SF39m+66bnrT3x8WB8sbxMH2hF4vw8RIa9ZzB1+c94rclMv/i8fngXmb/4A==",
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.31.0.tgz",
+      "integrity": "sha512-nCPVtv+QydBmb3Us2jCNAr1Dx3gST83VZxxrUQn/JAVFCOrmYOgUaPUz5bevummyNf30zfHsZhIKYAOD3ULfTA==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "multer": "^1.4.5-lts.1",
     "mysql2": "^2.3.3",
     "nodemailer": "^6.9.1",
-    "sequelize": "^6.26.0",
+    "sequelize": "^6.31.0",
     "tslib": "^2.5.0",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
### 📌 작업 내용
- sequelize_auto `^6.3.10`
- snake_case -> camelCase

node orm.js 실행 후 따로 넣어준 옵션 (기록용)
1. userInfo의 profileImgSrc
  1) attribute 이름 profileImg -> profileImgSrc (프론트에 보내는 변수 그대로)
  2) get() 메소드에 url formatter 추가 (매번 조합해서 보낼 필요 없음)
2. calculetInfo의 statistics
  가상 어트리뷰트로 cnt를 묶은 object인데, 실제로는 getCalculetInfo 한군데에서만 쓰이기 때문에 그냥 api 내에서 작성하면 어떨까 싶네요...

### 📌 변경 사항
패키지 새로 설치해주세요
`docker compose build` 혹은 쉘 접속해서 `npm i`

### ✅ Check List

- FE
  - [ ] warning 해결
  - [ ] console 주석
- BE
  - [ ] 새로운 api에 대한 에러 처리 (wrapper, 혹은 try-catch)
