### PR TITLE
[FIX] error handling logic

### DIFF
--- a/server/routes/test.js
+++ b/server/routes/test.js
@@ -6,6 +6,7 @@ const { auth } = require("../middleware/auth");
 const { models } = require("../models");
 const { deleteUser } = require("./users/deleteUser");
 const { CustomError } = require("../utils/CustomError");
+const { errorHandler } = require("../middleware/errorHandler");
 
 /**
  * @swagger
@@ -162,13 +163,16 @@ router.delete("/users/database", auth.validate, async (req, res) => {
  *        200:
  *          description: 성공
  */
-router.post("/login", async (req, res) => {
-  const { idToken } = await auth.postFirebase(
-    req.body.email,
-    req.body.password
-  );
-  res.status(200).send(idToken);
-});
+router.post(
+  "/login",
+  errorHandler.asyncWrapper(async (req, res) => {
+    const { idToken } = await auth.postFirebase(
+      req.body.email,
+      req.body.password
+    );
+    res.status(200).send(idToken);
+  })
+);
 
 // /**
 //  * @swagger


### PR DESCRIPTION
### 📌 작업 내용
admin용 firebase 에러 핸들링

문제가 되는 함수를 사용하는 곳은 2곳 입니다.
- swagger 간이 로그인
- admin 페이지 로그인

admin 페이지 로그인은 이미 try-catch 처리가 되어 있어서 문제가 없었는데, swagger 간이 로그인 부분에서는 에러 처리가 제대로 이루어지지 않아서 wrapper로 처리 했습니다.

### 📌 변경 사항
이후에 해당함수(`postEmailAndPassword`)를 사용한다면 사용하는 쪽에서 wrapper 혹은 try-catch로 처리해주어야 합니다.

### ✅ Check List
- BE
  - [x] 새로운 api에 대한 에러 처리 (wrapper, 혹은 try-catch)
