### PR TITLE
[ADD] custom component for post calculet

### DIFF
--- a/client/src/Router.js
+++ b/client/src/Router.js
@@ -14,6 +14,7 @@ import Search from "./pages/Search";
 import CalculetList from "./pages/CalculetList";
 import Profile from "./pages/Profile";
 import Setting from "./pages/Setting";
+import RegisterTest from "./pages/RegisterTest";
 
 // google-analytics
 import RouteChangeTracker from "./components/google-analytics/RouteChangeTracker";
@@ -45,6 +46,7 @@ function AppRouter({ isLoggedIn }) {
             <Auth isLoggedIn={isLoggedIn} authComponent={<Register />} />
           }
         />
+        <Route path={URL.REGISTER_TEST} element={<RegisterTest />} />
         <Route
           path={URL.LOGIN}
           element={<LoginContainer isLoggedIn={isLoggedIn} />}

--- a/client/src/components/PageUrls.js
+++ b/client/src/components/PageUrls.js
@@ -11,6 +11,9 @@ const URL = {
   // 계산기 저작
   REGISTER: "/register",
 
+  // 계산기 저작 테스트 페이지
+  REGISTER_TEST: "/register-test",
+
   // 검색 리스트
   SEARCH: "/search",
 

--- a/client/src/components/custom-components/TextComponent.js
+++ b/client/src/components/custom-components/TextComponent.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { TextField } from "@mui/material";
 
 /**
@@ -6,7 +7,7 @@ import { TextField } from "@mui/material";
  * props: 사용자가 입력한 텍스트 컴포넌트에 관한 정보들
  * @returns
  */
-function TextComponent(props) {
+const TextComponent = React.memo(function TextComponent(props) {
   return (
     <TextField
       id={props.param.name}
@@ -17,6 +18,6 @@ function TextComponent(props) {
       disabled={props.isDisabled}
     />
   );
-}
+});
 
 export default TextComponent;

--- a/client/src/components/custom-components/TextComponent.js
+++ b/client/src/components/custom-components/TextComponent.js
@@ -13,8 +13,8 @@ function TextComponent(props) {
       label={props.param.label}
       defaultValue={props.value}
       onChange={props.onChange}
-      required={props.isRequire}
-      disabled={props.isDisable}
+      required={props.isRequired}
+      disabled={props.isDisabled}
     />
   );
 }

--- a/client/src/components/custom-components/TextComponent.js
+++ b/client/src/components/custom-components/TextComponent.js
@@ -1,0 +1,22 @@
+import { TextField } from "@mui/material";
+
+/**
+ * 텍스트 필드 커스텀 컴포넌트
+ * @param {*} props
+ * props: 사용자가 입력한 텍스트 컴포넌트에 관한 정보들
+ * @returns
+ */
+function TextComponent(props) {
+  return (
+    <TextField
+      id={props.param.name}
+      label={props.param.label}
+      defaultValue={props.value}
+      onChange={props.onChange}
+      required={props.isRequire}
+      disabled={props.isDisable}
+    />
+  );
+}
+
+export default TextComponent;

--- a/client/src/components/register-test/Transformer.js
+++ b/client/src/components/register-test/Transformer.js
@@ -1,0 +1,14 @@
+import TextComponent from "../custom-components/TextComponent";
+
+/**
+ * 사용자 입력 객체를 컴포넌트로 변환해주는 함수
+ * @param {*} props
+ * props: 사용자가 입력한 컴포넌트 한 개의 정보들
+ */
+function Transformer(props) {
+  const { data } = props;
+  if (data.type === "STRING") {
+    return <TextComponent {...data} />;
+  }
+}
+export default Transformer;

--- a/client/src/pages/RegisterTest.js
+++ b/client/src/pages/RegisterTest.js
@@ -14,7 +14,7 @@ function RegisterTest() {
   const [testObj] = useState([
     {
       isInput: true,
-      isOutput: false,
+      isOutput: true,
       copyButton: true,
       isRequired: true,
       isDisabled: false,

--- a/client/src/pages/RegisterTest.js
+++ b/client/src/pages/RegisterTest.js
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from "react";
+import { PageScreenBox } from "../components/global-components/PageScreenBox";
+import Transformer from "../components/register-test/Transformer";
+
+/**
+ * 계산기 심플 등록 테스트 페이지
+ * - 사용자에게 입력받는 컴포넌트 정보를 testObj에 넣고, 이를 컴포넌트로 transform하는 로직
+ */
+function RegisterTest() {
+  const [isRender, setIsRender] = useState(false);
+  const [inputs, setInputs] = useState({});
+  const [outputs, setOutputs] = useState({});
+  const [components, setComponents] = useState([]);
+  const [testObj] = useState([
+    {
+      isOutput: false,
+      isCopy: true,
+      isRequire: true,
+      isDisable: false,
+      type: "STRING",
+      param: {
+        name: "test",
+        label: "입력",
+      },
+    },
+    {
+      isOutput: false,
+      isCopy: true,
+      isRequire: true,
+      isDisable: false,
+      type: "STRING",
+      param: {
+        name: "test2",
+        label: "입력2",
+      },
+    },
+  ]);
+
+  function onInputsChange(e) {
+    const { id, value } = e.target;
+    setInputs((inputs) => ({ ...inputs, [id]: value }));
+  }
+  function onOutputsChange(e) {
+    const { id, value } = e.target;
+    setOutputs((outputs) => ({ ...outputs, [id]: value }));
+  }
+
+  const transformerHandler = useCallback(() => {
+    const tempInputs = inputs;
+    const tempOutputs = outputs;
+    const tempComponents = [];
+    testObj.forEach((data) => {
+      const valId = data.param.name;
+      if (!data.isOutput) {
+        tempInputs[valId] = "";
+        data = {
+          ...data,
+          value: tempInputs[valId],
+          onChange: onInputsChange,
+        };
+      } else {
+        tempOutputs[valId] = "";
+        data = {
+          ...data,
+          value: tempOutputs[valId],
+          onChange: onOutputsChange,
+        };
+      }
+      tempComponents.push(data);
+    });
+    setInputs(tempInputs);
+    setOutputs(tempOutputs);
+    setComponents(tempComponents);
+  }, [inputs, outputs, testObj]);
+
+  useEffect(() => {
+    if (!isRender) {
+      transformerHandler();
+      setIsRender(true);
+    }
+  }, [isRender, transformerHandler]);
+
+  console.log(inputs);
+
+  return (
+    <PageScreenBox gap="2.4rem">
+      {components.map((component, index) => (
+        <Transformer key={index} data={component} />
+      ))}
+    </PageScreenBox>
+  );
+}
+export default RegisterTest;

--- a/client/src/pages/RegisterTest.js
+++ b/client/src/pages/RegisterTest.js
@@ -80,8 +80,6 @@ function RegisterTest() {
     }
   }, [isRender, transformerHandler]);
 
-  console.log(inputs);
-
   return (
     <PageScreenBox gap="2.4rem">
       {components.map((component, index) => (

--- a/client/src/pages/RegisterTest.js
+++ b/client/src/pages/RegisterTest.js
@@ -13,10 +13,11 @@ function RegisterTest() {
   const [components, setComponents] = useState([]);
   const [testObj] = useState([
     {
+      isInput: true,
       isOutput: false,
-      isCopy: true,
-      isRequire: true,
-      isDisable: false,
+      copyButton: true,
+      isRequired: true,
+      isDisabled: false,
       type: "STRING",
       param: {
         name: "test",
@@ -24,10 +25,11 @@ function RegisterTest() {
       },
     },
     {
-      isOutput: false,
-      isCopy: true,
-      isRequire: true,
-      isDisable: false,
+      isInput: false,
+      isOutput: true,
+      copyButton: true,
+      isRequired: true,
+      isDisabled: false,
       type: "STRING",
       param: {
         name: "test2",
@@ -51,19 +53,25 @@ function RegisterTest() {
     const tempComponents = [];
     testObj.forEach((data) => {
       const valId = data.param.name;
-      if (!data.isOutput) {
+      if (data.isInput) {
         tempInputs[valId] = "";
         data = {
           ...data,
           value: tempInputs[valId],
           onChange: onInputsChange,
         };
-      } else {
+      }
+      if (data.isOutput) {
         tempOutputs[valId] = "";
         data = {
           ...data,
           value: tempOutputs[valId],
-          onChange: onOutputsChange,
+          onChange: data.isInput
+            ? (e) => {
+                onInputsChange(e);
+                onOutputsChange(e);
+              }
+            : onOutputsChange,
         };
       }
       tempComponents.push(data);


### PR DESCRIPTION
### 📌 작업 내용
- 폴더 구조
```
├─components/custom-components // 커스텀 컴포넌트들 
│  ├─TextComponent.js // 텍스트 컴포넌트
│  ├─(ex) SelectComponent.js // 셀렉트 박스 컴포넌트
├─components/register-test // 계산기 심플 등록 관련한 로직 컴포넌트 (커스텀 컴포넌트보다 상위)
│  ├─Transformer.js // 객체 type에 맞는 컴포넌트 찾아서 반환하는 
├─pages
│  ├─RegisterTest.js // 테스트 페이지
```
- 작업 로직
  - 입/출력 컴포넌트에 대한 객체 배열이 주어짐 (아직 사용자 입력을 객체로 바꾸는 로직은 구현 X)
  - 각 객체 배열을 순회하며 input, output 확인 후 state 업데이트. 각 객체마다 value와 onChange 속성을 추가 
  - 객체 배열을 map으로 돌려 트랜스포머된 컴포넌트를 반환
  - 컴포넌트는 Type을 확인하여 미리 만들어진 컴포넌트를 반환해줌 
- `Input`만 대응 가능
  - `select` or `radio` 등 다중 선택에 대한 로직 고민 필요
---
05.19
- 노션에 컴포넌트 관리 모듈 페이지 추가 (객체 스키마 정보)
https://www.notion.so/c6754253b08c4cc48876420e4e9fc4c4?pvs=4

### ✅ Check List

- FE
  - [x] warning 해결
  - [x] console 주석
