### PR TITLE
[FIX] category api - handle converters

### DIFF
--- a/server/routes/category/getCategory.js
+++ b/server/routes/category/getCategory.js
@@ -4,6 +4,8 @@ const { models } = require("../../models");
  * 카테고리 목록 반환
  */
 async function getCategory(req, res) {
+  const CONVERTER = 0;
+  const CONVERTER_LABEL = "단위변환기";
   const categoryList = await models.category.findAll({
     include: [
       {
@@ -19,14 +21,22 @@ async function getCategory(req, res) {
         as: "sub",
       },
     ],
+    order: ["subId", "mainId"],
   });
 
   const responseData = {};
+  responseData[CONVERTER] = {
+    name: CONVERTER_LABEL,
+  };
   categoryList.map((element) => {
     if (responseData[element.mainId] === undefined) {
       responseData[element.mainId] = {
         name: element.main.name,
       };
+      // 단위변환기 모으기
+      if (element.subId === CONVERTER) {
+        responseData[CONVERTER][element.mainId] = element.main.name;
+      }
     }
 
     responseData[element.mainId][element.subId] = element.sub.name;


### PR DESCRIPTION
### 📌 작업 내용
카테고리 목록에서 단위변환기 따로 모아서 리턴하기.
아래 json의 0번키 참고


### 🌻 Frontend는 보아라
```json
{
  "0": {
    "1": "수학",
    "2": "과학-공학",
    "3": "경제-사회",
    "4": "일상",
    "name": "단위변환기"
  },
  "1": {
    "0": "단위변환기",
    "1": "계산",
    "2": "통계",
    "3": "기하",
    "99999": "기타",
    "name": "수학"
  },
  "2": {
    "0": "단위변환기",
    "4": "과학",
    "5": "공학",
    "99999": "기타",
    "name": "과학-공학"
  },
  "3": {
    "0": "단위변환기",
    "6": "경제",
    "99999": "기타",
    "name": "경제-사회"
  },
  "4": {
    "0": "단위변환기",
    "7": "시간 & 날짜",
    "8": "운동",
    "9": "쇼핑",
    "10": "학교",
    "99999": "기타",
    "name": "일상"
  },
  "99999": {
    "99999": "기타",
    "name": "기타"
  }
}
```
