### PR TITLE
[API] my calculet api - fix id & add get one calculet

### DIFF
--- a/server/models/tables/calculetInfoTemp.js
+++ b/server/models/tables/calculetInfoTemp.js
@@ -69,6 +69,12 @@ module.exports = function (sequelize, DataTypes) {
         unique: true,
         defaultValue: Sequelize.Sequelize.fn("uuid"),
       },
+      blocked: {
+        type: DataTypes.VIRTUAL,
+        get() {
+          return 2;
+        },
+      },
     },
     {
       sequelize,

--- a/server/routes/users/getMyCalculetInfo.js
+++ b/server/routes/users/getMyCalculetInfo.js
@@ -1,0 +1,43 @@
+const { models } = require("../../models");
+const { CustomError } = require("../../utils/CustomError");
+
+exports.getMyCalculetInfo = async (req, res) => {
+  const option = {
+    attributes: [
+      "id",
+      "title",
+      "description",
+      "categoryMainId",
+      "categorySubId",
+      "srcCode",
+      "manual",
+      "blocked",
+      "type",
+    ],
+    include: [
+      // contributor
+      {
+        model: models.userInfo,
+        required: true,
+        attributes: ["id", "userName", "profileImgSrc"],
+        as: "contributor",
+      },
+    ],
+    where: {
+      id: req.params.calculetId,
+      contributorId: res.locals.userId,
+    },
+  };
+
+  let calculet = null;
+  if (req.query.blocked === 2) {
+    calculet = await models.calculetInfoTemp.findOne(option);
+  } else {
+    calculet = await models.calculetInfo.findOne(option);
+  }
+
+  if (calculet === null) {
+    throw new CustomError(400, 0);
+  }
+  res.status(200).send(calculet);
+};

--- a/server/routes/users/getMyCalculetInfo.js
+++ b/server/routes/users/getMyCalculetInfo.js
@@ -37,7 +37,7 @@ exports.getMyCalculetInfo = async (req, res) => {
   }
 
   if (calculet === null) {
-    throw new CustomError(400, 0);
+    throw new CustomError(404, 0);
   }
   res.status(200).send(calculet);
 };

--- a/server/routes/users/getMyCalculetList.js
+++ b/server/routes/users/getMyCalculetList.js
@@ -13,16 +13,18 @@ function mergeCalculets({ myCalculetList, myCalculetTempList }) {
   let tempIdx = 0;
   myCalculetList.map((calculet) => {
     if (calculet.isEdit) {
+      let calculetTemp = null;
       if (calculet.id === myCalculetTempList[tempIdx].calculetId) {
-        calculet.calculetTemp = myCalculetTempList[tempIdx++];
+        calculetTemp = myCalculetTempList[tempIdx++];
       } else {
         // 만약 id가 일치하지 않는다면 find연산으로 수정중인 계산기 찾기
         console.log("id 불일치로 find연산 실행");
-        const calculetTemp = myCalculetTempList.find(
+        calculetTemp = myCalculetTempList.find(
           (e) => e.calculetId === calculet.id
         );
-        calculet.calculetTemp = calculetTemp;
       }
+      delete calculetTemp.calculetId;
+      calculet.calculetTemp = calculetTemp;
     }
   });
   return myCalculetList;
@@ -56,13 +58,13 @@ exports.getMyCalculetList = async (req, res) => {
   // get calculet info & calculet info temp (full outer join)
   const sqlFull = `
     SELECT Info.id as id, Info.title, Info.description, Info.category_main_id as categoryMainId, Info.category_sub_id as categorySubId, Info.created_at as createdAt,
-    Info.view_cnt as viewCnt, Info.like_cnt as likeCnt, Info.bookmark_cnt as bookmarkCnt, Info.blocked, IF(Temp.id is NULL, False, True) as isEdit, Info.id as calculetId, NULL as calculetTemp
+    Info.view_cnt as viewCnt, Info.like_cnt as likeCnt, Info.bookmark_cnt as bookmarkCnt, Info.blocked, IF(Temp.id is NULL, False, True) as isEdit, NULL as calculetTemp
     FROM calculet_info Info
     LEFT JOIN calculet_info_temp Temp ON Info.id = Temp.calculet_id
     WHERE Info.contributor_id = '${res.locals.userId}'
     UNION
     SELECT Temp.id, Temp.title, Temp.description, Temp.category_main_id as categoryMainId, Temp.category_sub_id as categorySubId, Temp.created_at as createdAt, 
-    0 as viewCnt, 0 as likeCnt, 0 as bookmarkCnt, 2 as blocked, False as isEdit, Temp.calculet_id as calculetId, NULL as calculetTemp
+    0 as viewCnt, 0 as likeCnt, 0 as bookmarkCnt, 2 as blocked, False as isEdit, NULL as calculetTemp
     FROM calculet_info Info
     RIGHT JOIN calculet_info_temp Temp ON Info.id = Temp.calculet_id
     WHERE Info.id is NULL and Temp.contributor_id = '${res.locals.userId}'

--- a/server/routes/users/index.js
+++ b/server/routes/users/index.js
@@ -10,6 +10,7 @@ const { signUp } = require("./signUp");
 const { updateUser } = require("./updateUser");
 const { deleteUser } = require("./deleteUser");
 const { me } = require("./getMyInfo");
+const { getMyCalculetInfo } = require("./getMyCalculetInfo");
 const { getMyCalculetList } = require("./getMyCalculetList");
 const { updateMyCalculet } = require("./updateMyCalculet");
 const { deleteMyCalculet } = require("./deleteMyCalculet");
@@ -121,6 +122,31 @@ router.get("/me/profile", auth.validate, errorHandler.dbWrapper(me.detail));
  *                $ref: "#/components/schemas/userSimpleInfo"
  */
 router.get("/me", auth.validate, errorHandler.dbWrapper(me.default));
+
+/**
+ * @swagger
+ *  /api/users/me/calculet/{calculetId}:
+ *    get:
+ *      parameters:
+ *        - $ref: "#/components/parameters/calculetId"
+ *        - $ref: "#/components/parameters/blocked"
+ *      tags: [users-calculet]
+ *      summary: 로그인 한 사용자(본인)의 특정 마이 계산기 요청 <Auth>
+ *      description: 마이 계산기 정보
+ *      responses:
+ *        200:
+ *          $ref: "#/components/responses/myCalculetInfo"
+ */
+router.get(
+  "/me/calculet/:calculetId",
+  auth.validate,
+  [
+    param("calculetId").isUUID(),
+    query("blocked").isInt({ gt: -1, lt: 3 }).toInt(),
+    inputValidator,
+  ],
+  errorHandler.dbWrapper(getMyCalculetInfo)
+);
 
 /**
  * @swagger

--- a/server/routes/users/index.js
+++ b/server/routes/users/index.js
@@ -156,7 +156,7 @@ router.put(
   "/me/calculet",
   [
     auth.validate,
-    body("calculetInfo.calculetId").isUUID(),
+    body("calculetInfo.id").isUUID(),
     body(["calculetInfo.categoryMainId", "calculetInfo.categorySubId"])
       .isInt()
       .toInt(),
@@ -166,6 +166,7 @@ router.put(
     body("calculetInfo.srcCode").notEmpty(),
     body("calculetInfo.manual").isString(),
     body("calculetInfo.type").isInt({ min: 0, max: 1 }).toInt(),
+    body("calculetInfo.blocked").isInt({ min: 0, max: 2 }).toInt(),
     inputValidator,
   ],
   errorHandler.dbWrapper(updateMyCalculet)

--- a/server/routes/users/updateMyCalculet.js
+++ b/server/routes/users/updateMyCalculet.js
@@ -2,51 +2,74 @@ const { models } = require("../../models");
 const { CustomError } = require("../../utils/CustomError");
 const { matchedData } = require("express-validator");
 
+/**
+ * 계산기 ID에 대한 key가 주어졌을 때, where 옵션을 리턴하는 함수
+ * @param {*} calculetKey 계산기 ID 필드 이름 (id or calculetId)
+ * @param {*} calculetInfo 계산기 정보
+ * @returns object
+ */
+function getWhereOption(calculetKey, calculetInfo) {
+  return {
+    where: {
+      [calculetKey]: calculetInfo.id,
+      contributorId: calculetInfo.contributorId,
+    },
+  };
+}
+
+/**
+ * calculet_info, calculet_info_temp 테이블을 조회해서 각각 계산기를 얻어오는 함수
+ * @param {*} calculetInfo 계산기 정보들
+ */
+async function getCalculet(calculetInfo, whereIdOption) {
+  if (calculetInfo.blocked === 2) {
+    return await models.calculetInfoTemp.findOne(whereIdOption);
+  }
+  // check exist calculet temp (because if exist calculet temp, then should modify temp table, not info)
+  const temp = await models.calculetInfoTemp.findOne(
+    getWhereOption("calculetId", calculetInfo)
+  );
+  if (temp) {
+    console.log("Editing temp calculet is exist");
+    throw new CustomError(400, 1);
+  }
+  return await models.calculetInfo.findOne(whereIdOption);
+}
+
+/**
+ * [고려해야 할 케이스]
+ *
+ *                                   <calculetTemp 삭제> <update log 삭제> <registered> <calculetTemp 생성> <update log 생성>
+ * 1. 첫 등록 후 등록 대기 중인 계산기         O                  X             False             O                  X
+ * 2. 등록 이후 수정 요청 중인 계산기          O                  O             True              O                  O
+ * 3. 등록 완료된 계산기 (수정 중 없음)        X                  X             True              O                  O
+ */
 async function updateMyCalculet(req, res) {
   const bodyData = matchedData(req, { locations: ["body"] });
   const { calculetInfo, updateMessage } = bodyData;
 
-  const whereOption = {
-    where: {
-      id: calculetInfo.id,
-      contributorId: res.locals.userId,
-    },
-  };
+  // set calculet id & contributor id
+  calculetInfo.calculetId = calculetInfo.id;
+  calculetInfo.contributorId = res.locals.userId;
 
-  let calculet = null;
-  let calculetTemp = null;
-  let calculetId = calculetInfo.id;
-  if (calculetInfo.blocked === 2) {
-    calculetTemp = await models.calculetInfoTemp.findOne(whereOption);
-  } else {
-    // check exist calculet temp (because if exist calculet temp, then should modify temp table, not info)
-    const temp = await models.calculetInfoTemp.findOne({
-      where: {
-        calculetId: calculetId,
-        contributorId: res.locals.userId,
-      },
-    });
-    if (temp) {
-      throw new CustomError(400, 1);
-    }
-    calculet = await models.calculetInfo.findOne(whereOption);
-  }
+  const whereIdOption = getWhereOption("id", calculetInfo);
+  const calculet = await getCalculet(calculetInfo, whereIdOption);
 
-  if (calculet === null && calculetTemp === null) {
+  if (calculet === null) {
     throw new CustomError(400, 0);
   }
 
-  // check exist calculet temp data
-  if (calculetTemp !== null) {
-    calculetId = calculetTemp.calculetId;
+  // if blocked === 2, then delete temp & update log
+  if (calculetInfo.blocked === 2) {
+    calculetInfo.calculetId = calculet.calculetId;
 
     // delete temp data
-    await models.calculetInfoTemp.destroy(whereOption);
+    await models.calculetInfoTemp.destroy(whereIdOption);
 
     // if registered is true, then delete update log (latest)
-    if (calculetTemp.registered) {
+    if (calculet.registered) {
       const latestUpdateLog = await models.calculetUpdateLog.findOne({
-        where: { calculetId: calculetId },
+        where: { calculetId: calculet.calculetId },
         order: [["createdAt", "DESC"]],
         limit: 1,
       });
@@ -54,10 +77,14 @@ async function updateMyCalculet(req, res) {
     }
   }
 
-  if (calculet !== null || (calculetTemp !== null && calculetTemp.registered)) {
+  // if only calculet info or calculet temp & registered true
+  if (
+    calculetInfo.blocked !== 2 ||
+    (calculetInfo.blocked === 2 && calculet.registered)
+  ) {
     // create update log
     await models.calculetUpdateLog.create({
-      calculetId: calculetId,
+      calculetId: calculetInfo.calculetId,
       message: updateMessage,
     });
 
@@ -67,8 +94,6 @@ async function updateMyCalculet(req, res) {
 
   // create calculet info temp
   delete calculetInfo.id;
-  calculetInfo.calculetId = calculetId;
-  calculetInfo.contributorId = res.locals.userId;
   await models.calculetInfoTemp.create(calculetInfo);
   res.status(204).send();
 }

--- a/server/routes/users/updateMyCalculet.js
+++ b/server/routes/users/updateMyCalculet.js
@@ -8,14 +8,29 @@ async function updateMyCalculet(req, res) {
 
   const whereOption = {
     where: {
-      calculetId: calculetInfo.calculetId,
+      id: calculetInfo.id,
       contributorId: res.locals.userId,
     },
   };
-  const calculet = await models.calculetInfo.findOne({
-    where: { id: calculetInfo.calculetId, contributorId: res.locals.userId },
-  });
-  const calculetTemp = await models.calculetInfoTemp.findOne(whereOption);
+
+  let calculet = null;
+  let calculetTemp = null;
+  let calculetId = calculetInfo.id;
+  if (calculetInfo.blocked === 2) {
+    calculetTemp = await models.calculetInfoTemp.findOne(whereOption);
+  } else {
+    // check exist calculet temp (because if exist calculet temp, then should modify temp table, not info)
+    const temp = await models.calculetInfoTemp.findOne({
+      where: {
+        calculetId: calculetId,
+        contributorId: res.locals.userId,
+      },
+    });
+    if (temp) {
+      throw new CustomError(400, 1);
+    }
+    calculet = await models.calculetInfo.findOne(whereOption);
+  }
 
   if (calculet === null && calculetTemp === null) {
     throw new CustomError(400, 0);
@@ -23,20 +38,26 @@ async function updateMyCalculet(req, res) {
 
   // check exist calculet temp data
   if (calculetTemp !== null) {
-    // delete temp data & update log (latest)
+    calculetId = calculetTemp.calculetId;
+
+    // delete temp data
     await models.calculetInfoTemp.destroy(whereOption);
-    const latestUpdateLog = await models.calculetUpdateLog.findOne({
-      where: { calculetId: calculetInfo.calculetId },
-      order: [["createdAt", "DESC"]],
-      limit: 1,
-    });
-    latestUpdateLog.destroy();
+
+    // if registered is true, then delete update log (latest)
+    if (calculetTemp.registered) {
+      const latestUpdateLog = await models.calculetUpdateLog.findOne({
+        where: { calculetId: calculetId },
+        order: [["createdAt", "DESC"]],
+        limit: 1,
+      });
+      latestUpdateLog.destroy();
+    }
   }
 
-  if (calculet !== null) {
+  if (calculet !== null || (calculetTemp !== null && calculetTemp.registered)) {
     // create update log
     await models.calculetUpdateLog.create({
-      calculetId: calculetInfo.calculetId,
+      calculetId: calculetId,
       message: updateMessage,
     });
 
@@ -45,6 +66,8 @@ async function updateMyCalculet(req, res) {
   }
 
   // create calculet info temp
+  delete calculetInfo.id;
+  calculetInfo.calculetId = calculetId;
   calculetInfo.contributorId = res.locals.userId;
   await models.calculetInfoTemp.create(calculetInfo);
   res.status(204).send();

--- a/server/routes/users/updateMyCalculet.js
+++ b/server/routes/users/updateMyCalculet.js
@@ -56,7 +56,7 @@ async function updateMyCalculet(req, res) {
   const calculet = await getCalculet(calculetInfo, whereIdOption);
 
   if (calculet === null) {
-    throw new CustomError(400, 0);
+    throw new CustomError(404, 0);
   }
 
   // if blocked === 2, then delete temp & update log

--- a/server/swagger/calculets.yml
+++ b/server/swagger/calculets.yml
@@ -57,6 +57,12 @@ components:
       schema:
         type: string
       example: title
+    blocked:
+      in: query
+      required: true
+      name: blocked
+      schema:
+        $ref: "#/components/schemas/calculet/properties/blocked"
   responses:
     likeResult:
       content:

--- a/server/swagger/calculets.yml
+++ b/server/swagger/calculets.yml
@@ -262,7 +262,7 @@ components:
     calculetUpdate:
       type: object
       properties:
-        calculetId:
+        id:
           $ref: "#/components/schemas/calculetId"
         title:
           $ref: "#/components/schemas/calculet/properties/title"
@@ -278,6 +278,8 @@ components:
           $ref: "#/components/schemas/calculet/properties/categorySubId"
         type:
           $ref: "#/components/schemas/calculet/properties/type"
+        blocked:
+          $ref: "#/components/schemas/calculet/properties/blocked"
     myCalculetInfo:
       type: object
       properties:

--- a/server/swagger/calculets.yml
+++ b/server/swagger/calculets.yml
@@ -306,5 +306,3 @@ components:
         isEdit:
           type: boolean
           description: 현재 수정중인 계산기가 있는지에 대한 여부
-        calculetId:
-          $ref: "#/components/schemas/calculetId"

--- a/server/swagger/users.yml
+++ b/server/swagger/users.yml
@@ -47,6 +47,15 @@ components:
       schema:
         $ref: "#/components/schemas/userInfo/properties/id"
   responses:
+    myCalculetInfo:
+      description: 계산기 불러오기 성공
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/calculet"
+            properties:
+              id:
+                $ref: "#/components/schemas/calculetId"
     myCalculetList:
       description: 마이 계산기 리스트
       content:

--- a/server/swagger/users.yml
+++ b/server/swagger/users.yml
@@ -78,8 +78,6 @@ components:
                 isEdit:
                   type: boolean
                   description: 현재 수정중인 계산기가 있는지에 대한 여부
-                calculetId:
-                  $ref: "#/components/schemas/calculetId"
                 calculetTemp:
                   $ref: "#/components/schemas/myCalculetInfo"
     userPublicInfo:


### PR DESCRIPTION
### 📌 작업 내용
- 특정 마이 계산기 GET API 추가 (`users/me/calculet/:calculetId?blocked`)
- 기존 update api와 get api에서 calculetId 필드 제외하고 id값만 받고, 보내주는 것으로 수정

### 🌻 Frontend는 보아라
- 계산기 임시 테이블의 calculetId필드(계산기의 실제 UUID, 계산기 publish하면 등록되는 ID)에 관한 것은 모두 뺐습니다! 이제 등록된 계산기든, 신고 계산기든, 임시 계산기든 **id 필드**로 계산기 id는 보내주시면 됩니다.

### ✅ Check List

- BE
  - [x] 새로운 api에 대한 에러 처리 (wrapper, 혹은 try-catch)
