### PR TITLE
[FEAT] Register editor component (refactoring + radio, input helper, calculet button, typography)

### DIFF
--- a/client/src/components/organisms/register-editor/CalculetButtonComponent.js
+++ b/client/src/components/organisms/register-editor/CalculetButtonComponent.js
@@ -1,0 +1,21 @@
+import { Button } from "@mui/material";
+
+/**
+ * 사용자가 저작한 계산기의 계산하기 버튼 컴포넌트
+ * @param {*} props
+ * [TODO] onClick함수 props에서 받아와서 사용
+ * @returns
+ */
+function CalculetButtonComponent(props) {
+  return (
+    <Button
+      variant="contained"
+      onClick={props.onClick}
+      sx={{ width: "fit-content", height: "fit-content" }}
+    >
+      계산하기
+    </Button>
+  );
+}
+
+export default CalculetButtonComponent;

--- a/client/src/components/organisms/register-editor/CheckboxComponent.js
+++ b/client/src/components/organisms/register-editor/CheckboxComponent.js
@@ -1,10 +1,10 @@
 import { Checkbox, FormControlLabel } from "@mui/material";
 
-function CheckboxComponent({ data, label }) {
+function CheckboxComponent(props) {
   return (
     <FormControlLabel
-      control={<Checkbox {...data} checked={data.value} />}
-      label={label}
+      control={<Checkbox {...props} checked={props.value} />}
+      label={props.label}
     />
   );
 }

--- a/client/src/components/organisms/register-editor/ComponentForm.js
+++ b/client/src/components/organisms/register-editor/ComponentForm.js
@@ -10,6 +10,7 @@ import {
 import { Common, Components, Option } from "./ComponentOptions";
 import { useDispatch, useSelector } from "react-redux";
 import { onUpdateComponent } from "../../../modules/calculetEditor";
+import { TYPOGRAPHY, TEXT_FIELD } from "../../../constants/calculetComponent";
 
 /**
  * 컴포넌트 속성 하나에 대한 정보를 받아서, 인풋 필드로 바꿔주는 함수
@@ -85,8 +86,8 @@ function ComponentForm({ componentId, componentType }) {
   // isInput 속성 관리
   useEffect(() => {
     switch (componentType) {
-      case "textField":
-      case "typography":
+      case TEXT_FIELD:
+      case TYPOGRAPHY:
         dispatch(
           onUpdateComponent({ componentId, targetId: "isInput", value: true })
         );

--- a/client/src/components/organisms/register-editor/ComponentForm.js
+++ b/client/src/components/organisms/register-editor/ComponentForm.js
@@ -11,6 +11,7 @@ import {
   PROPERTY_TYPE_STRING,
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_TYPE_SELECT,
+  PROPERTY_OPTION_START_NUMBER,
 } from "../../../constants/calculetComponent";
 
 /**
@@ -50,7 +51,7 @@ function ComponentForm({ componentId, componentType }) {
     ...Common,
     ...Components[componentType],
   });
-  const [optionIdx, setOptionIdx] = useState(0); // 단일 선택 컴포넌트에 대한 옵션 개수
+  const [optionIdx, setOptionIdx] = useState(PROPERTY_OPTION_START_NUMBER + 1); // 단일 선택 컴포넌트에 대한 옵션 개수
 
   // isInput 속성 관리
   useEffect(() => {

--- a/client/src/components/organisms/register-editor/ComponentForm.js
+++ b/client/src/components/organisms/register-editor/ComponentForm.js
@@ -1,16 +1,17 @@
 import { useCallback, useState, useEffect } from "react";
-import {
-  Grid,
-  FormControlLabel,
-  TextField,
-  Checkbox,
-  Select,
-  MenuItem,
-} from "@mui/material";
+import { Grid, TextField } from "@mui/material";
 import { Common, Components, Option } from "./ComponentOptions";
 import { useDispatch, useSelector } from "react-redux";
+import SelectComponent from "./SelectComponent";
+import CheckboxComponent from "./CheckboxComponent";
 import { onUpdateComponent } from "../../../modules/calculetEditor";
-import { TYPOGRAPHY, TEXT_FIELD } from "../../../constants/calculetComponent";
+import {
+  TYPOGRAPHY,
+  TEXT_FIELD,
+  PROPERTY_TYPE_STRING,
+  PROPERTY_TYPE_BOOLEAN,
+  PROPERTY_TYPE_SELECT,
+} from "../../../constants/calculetComponent";
 
 /**
  * 컴포넌트 속성 하나에 대한 정보를 받아서, 인풋 필드로 바꿔주는 함수
@@ -20,47 +21,15 @@ import { TYPOGRAPHY, TEXT_FIELD } from "../../../constants/calculetComponent";
  * @param {function} onChange 컴포넌트 속성의 onChange 함수
  * @returns
  */
-function TransformField({ id, data, value, onChange }) {
-  switch (data.type) {
-    case "string":
-      return (
-        <TextField
-          id={id}
-          label={data.name}
-          value={value === undefined ? "" : value}
-          onChange={onChange}
-          required={data.required}
-        />
-      );
-    case "bool":
-      return (
-        <FormControlLabel
-          control={
-            <Checkbox
-              id={id}
-              checked={value === undefined ? false : value}
-              onChange={onChange}
-            />
-          }
-          label={data.name}
-          required={data.required}
-        />
-      );
-    case "select":
-      return (
-        <Select
-          name={id}
-          value={value === undefined ? data.options[0].value : value}
-          onChange={onChange}
-          required={data.required}
-        >
-          {data.options.map((option, index) => (
-            <MenuItem key={index} value={option.value}>
-              {option.name}
-            </MenuItem>
-          ))}
-        </Select>
-      );
+function TransformField(props) {
+  const { type, ...properties } = props;
+  switch (type) {
+    case PROPERTY_TYPE_STRING:
+      return <TextField {...properties} />;
+    case PROPERTY_TYPE_BOOLEAN:
+      return <CheckboxComponent {...properties} />;
+    case PROPERTY_TYPE_SELECT:
+      return <SelectComponent {...properties} />;
     default:
       return;
   }
@@ -77,7 +46,7 @@ function ComponentForm({ componentId, componentType }) {
   const inputs = useSelector(
     (state) => state.calculetEditor.components[componentId]
   ); // 컴포넌트 속성에 대한 인풋값
-  const [property, setProperty] = useState({
+  const [properties, setProperties] = useState({
     ...Common,
     ...Components[componentType],
   });
@@ -99,23 +68,23 @@ function ComponentForm({ componentId, componentType }) {
   // 컴포넌트 속성 인풋 onChange 함수
   const onInputsChange = useCallback(
     (e) => {
-      let { id, value } = e.target;
-      if (id && property[id].type === "bool") {
+      let { id, value } = e.target; // id: componentOption의 key값 (속성 이름)
+      if (id && properties[id].type === PROPERTY_TYPE_BOOLEAN) {
         value = e.target.checked;
       } else if (id === undefined) {
         id = e.target.name;
       }
       dispatch(onUpdateComponent({ componentId, targetId: id, value }));
     },
-    [property, componentId, dispatch]
+    [properties, componentId, dispatch]
   );
 
-  // 입력 검증 필요
+  // TODO 입력 검증 필요
   // // 속성이 유효한지 확인하는 함수
   // const invalidComponentOption = useCallback(
   //   (data) => {
-  //     for (const key in property) {
-  //       if (property[key].required && !inputs[key]) {
+  //     for (const key in properties) {
+  //       if (properties[key].required && !inputs[key]) {
   //         return false;
   //       }
   //     }
@@ -124,14 +93,14 @@ function ComponentForm({ componentId, componentType }) {
   //     }
   //     return true;
   //   },
-  //   [property, inputs]
+  //   [properties, inputs]
   // );
 
   // 옵션 추가하는 함수
   const addOption = useCallback(() => {
-    setProperty((property) => ({
-      ...property,
-      options: [...property.options, { ...Option, id: optionIdx }],
+    setProperties((properties) => ({
+      ...properties,
+      options: [...properties.options, { ...Option, id: optionIdx }],
     }));
     if (!inputs.options) {
       dispatch(
@@ -153,9 +122,9 @@ function ComponentForm({ componentId, componentType }) {
   const deleteOption = useCallback(
     (e) => {
       const target = e.target.parentElement;
-      setProperty((property) => ({
-        ...property,
-        options: property.options.filter((o) => o.id !== Number(target.id)),
+      setProperties((properties) => ({
+        ...properties,
+        options: properties.options.filter((op) => op.id !== Number(target.id)),
       }));
       const { [target.id]: temp, ...rest } = inputs.options;
       dispatch(
@@ -185,35 +154,39 @@ function ComponentForm({ componentId, componentType }) {
     [inputs.options, componentId, dispatch]
   );
 
-  // console.log("속성 컴포넌트 정보", property);
+  // console.log("속성 컴포넌트 정보", properties);
   // console.log("컴포넌트 옵션 정보", inputs);
 
   return (
     <Grid container sx={{ backgroundColor: "white" }}>
       <>
-        {Object.entries(property).map(([id, data], index) => (
+        {Object.entries(properties).map(([id, property], index) => (
           <TransformField
+            {...property}
             key={index}
             id={id}
-            data={data}
-            value={inputs[id]}
+            value={inputs[id] === undefined ? property.value : inputs[id]}
             onChange={onInputsChange}
           />
         ))}
       </>
-      {property.options && (
+      {properties.options && (
         <div>
           <button onClick={addOption}>옵션 추가</button>
-          {property.options.map((data, index1) => (
-            <div id={data.id} key={index1}>
-              {Object.entries(data).map(
-                ([id, data2], index2) =>
-                  id !== "id" && (
+          {properties.options.map((option, optionIdx) => (
+            <div id={option.id} key={optionIdx}>
+              {Object.entries(option).map(
+                ([key, optionProperty]) =>
+                  key !== "id" && (
                     <TransformField
-                      key={`${id}${data.id}`}
-                      id={`${id} ${data.id}`}
-                      data={data2}
-                      value={inputs.options[data.id][id]}
+                      {...optionProperty}
+                      key={`${key}${option.id}`}
+                      id={`${key} ${option.id}`}
+                      value={
+                        inputs.options[option.id][key] === undefined
+                          ? optionProperty.value
+                          : inputs.options[option.id][key]
+                      }
                       onChange={onOptionsChange}
                     />
                   )

--- a/client/src/components/organisms/register-editor/ComponentForm.js
+++ b/client/src/components/organisms/register-editor/ComponentForm.js
@@ -1,9 +1,8 @@
 import { useCallback, useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
 import { Grid, TextField } from "@mui/material";
 import { Common, Components, Option } from "./ComponentOptions";
-import { useDispatch, useSelector } from "react-redux";
-import SelectComponent from "./SelectComponent";
-import CheckboxComponent from "./CheckboxComponent";
 import { onUpdateComponent } from "../../../modules/calculetEditor";
 import {
   TYPOGRAPHY,
@@ -12,7 +11,12 @@ import {
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_TYPE_SELECT,
   PROPERTY_OPTION_START_NUMBER,
+  // PROPERTY_TYPE_DATE,
 } from "../../../constants/calculetComponent";
+
+// import DatePickerComponent from "./DatePickerComponent";
+import SelectComponent from "./SelectComponent";
+import CheckboxComponent from "./CheckboxComponent";
 
 /**
  * 컴포넌트 속성 하나에 대한 정보를 받아서, 인풋 필드로 바꿔주는 함수
@@ -31,6 +35,8 @@ function TransformField(props) {
       return <CheckboxComponent {...properties} />;
     case PROPERTY_TYPE_SELECT:
       return <SelectComponent {...properties} />;
+    // case PROPERTY_TYPE_DATE:
+    //   return <DatePickerComponent {...properties} />;
     default:
       return;
   }

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -145,6 +145,15 @@ const Components = {
   radio: {
     options: [DefaultOption],
   },
+  inputHelper: {
+    target: {
+      type: PROPERTY_TYPE_STRING,
+      label: "입력될 입력창의 변수명",
+      value: "",
+      required: true,
+    },
+    options: [DefaultOption],
+  },
 };
 
 export { Common, Option, Components };

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -3,6 +3,7 @@ import {
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_TYPE_SELECT,
   PROPERTY_OPTION_START_NUMBER,
+  // PROPERTY_TYPE_DATE,
 } from "../../../constants/calculetComponent";
 
 /**
@@ -164,6 +165,14 @@ const Components = {
       required: false,
     },
   },
+  // datePicker: {
+  //   value: {
+  //     type: PROPERTY_TYPE_DATE,
+  //     label: "기본값",
+  //     value: "",
+  //     required: false,
+  //   },
+  // },
   select: {
     options: [DefaultOption],
   },

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -154,6 +154,7 @@ const Components = {
     },
     options: [DefaultOption],
   },
+  calculetButton: {},
 };
 
 export { Common, Option, Components };

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -78,30 +78,69 @@ const DefaultOption = {
 };
 
 /**
+ * 텍스트 컴포넌트에 들어가는 공통 속성 정보
+ */
+const TextOption = {
+  isInput: {
+    type: PROPERTY_TYPE_BOOLEAN,
+    label: "입력 여부",
+    value: false,
+    required: false,
+  },
+  isOutput: {
+    type: PROPERTY_TYPE_BOOLEAN,
+    label: "출력 여부",
+    value: false,
+    required: false,
+  },
+  copyButton: {
+    type: PROPERTY_TYPE_BOOLEAN,
+    label: "복사 버튼",
+    value: false,
+    required: false,
+  },
+};
+
+/**
  * 컴포넌트 속성들에 대한 정보를 담은 객체
  */
 const Components = {
+  typography: {
+    ...TextOption,
+    variant: {
+      type: PROPERTY_TYPE_SELECT,
+      label: "종류",
+      options: [
+        { value: "body1", label: "본문 1" },
+        { value: "body2", label: "본문 2" },
+        { value: "button", label: "굵은 글씨" },
+        { value: "caption", label: "설명 글씨" },
+        { value: "h1", label: "제목 1" },
+        { value: "h2", label: "제목 2" },
+        { value: "h3", label: "제목 3" },
+        { value: "h4", label: "제목 4" },
+        { value: "h5", label: "제목 5" },
+        { value: "h6", label: "제목 6" },
+        { value: "overline", label: "얇은 글씨" },
+        { value: "subtitle1", label: "소제목 1" },
+        { value: "subtitle2", label: "소제목 2" },
+        { value: "string", label: "텍스트" },
+      ],
+      required: false,
+      value: "body1",
+    },
+    content: {
+      type: PROPERTY_TYPE_STRING,
+      label: "내용",
+      value: "",
+      required: true,
+    },
+  },
   textField: {
-    isInput: {
-      type: PROPERTY_TYPE_BOOLEAN,
-      label: "입력 여부",
-      value: false,
-      required: false,
-    },
-    isOutput: {
-      type: PROPERTY_TYPE_BOOLEAN,
-      label: "출력 여부",
-      value: false,
-      required: false,
-    },
-    copyButton: {
-      type: PROPERTY_TYPE_BOOLEAN,
-      label: "복사 버튼",
-      value: false,
-      required: false,
-    },
+    ...TextOption,
     type: {
       type: PROPERTY_TYPE_SELECT,
+      label: "타입",
       options: [
         { value: "text", label: "문자열" },
         { value: "email", label: "이메일" },

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -1,33 +1,44 @@
+import {
+  PROPERTY_TYPE_STRING,
+  PROPERTY_TYPE_BOOLEAN,
+  PROPERTY_TYPE_SELECT,
+} from "../../../constants/calculetComponent";
+
 /**
  * 컴포넌트들에 공통으로 쓰이는 속성
  * key : 속성 이름 (mui에서 쓰이는 속성 이름과 동일)
  * value :
- *   - type : string - text field, bool - checkbox, select - select box
- *   - name : 페이지에 표시되는 이름 (label)
+ *   - type : PROPERTY_TYPE_STRING - text field, PROPERTY_TYPE_BOOLEAN - checkbox, PROPERTY_TYPE_SELECT - select box
+ *   - value : 기본값
+ *   - label : 페이지에 표시되는 이름
  *   - required : 필수로 입력되어야 하는 속성인지
  *   - options : select box에 표시되는 옵션들
  *     - value : 옵션 id (mui에 넘어갈 value)
- *     - name : 페이지에 표시되는 이름 (label)
+ *     - label : 페이지에 표시되는 이름
  */
 const Common = {
   id: {
-    type: "string",
-    name: "변수명",
+    type: PROPERTY_TYPE_STRING,
+    label: "변수명",
+    value: "",
     required: true,
   },
   label: {
-    type: "string",
-    name: "설명",
+    type: PROPERTY_TYPE_STRING,
+    label: "설명",
+    value: "",
     required: true,
   },
   required: {
-    type: "bool",
-    name: "필수 여부",
+    type: PROPERTY_TYPE_BOOLEAN,
+    label: "필수 여부",
+    value: false,
     required: false,
   },
   disabled: {
-    type: "bool",
-    name: "비활성화",
+    type: PROPERTY_TYPE_BOOLEAN,
+    label: "비활성화",
+    value: false,
     required: false,
   },
 };
@@ -37,13 +48,15 @@ const Common = {
  */
 const Option = {
   value: {
-    type: "string",
-    name: "value",
+    type: PROPERTY_TYPE_STRING,
+    label: "value",
+    value: "",
     required: true,
   },
   label: {
-    type: "string",
-    name: "label",
+    type: PROPERTY_TYPE_STRING,
+    label: "label",
+    value: "",
     required: true,
   },
 };
@@ -54,38 +67,47 @@ const Option = {
 const Components = {
   textField: {
     isInput: {
-      type: "bool",
-      name: "입력 여부",
+      type: PROPERTY_TYPE_BOOLEAN,
+      label: "입력 여부",
+      value: false,
       required: false,
     },
     isOutput: {
-      type: "bool",
-      name: "출력 여부",
+      type: PROPERTY_TYPE_BOOLEAN,
+      label: "출력 여부",
+      value: false,
       required: false,
     },
     copyButton: {
-      type: "bool",
-      name: "복사 버튼",
+      type: PROPERTY_TYPE_BOOLEAN,
+      label: "복사 버튼",
+      value: false,
       required: false,
     },
     type: {
-      type: "select",
+      type: PROPERTY_TYPE_SELECT,
       options: [
-        { value: "text", name: "문자열" },
-        { value: "email", name: "이메일" },
-        { value: "tel", name: "전화번호" },
-        { value: "number", name: "숫자" },
-        { value: "password", name: "비밀번호" },
+        { value: "text", label: "문자열" },
+        { value: "email", label: "이메일" },
+        { value: "tel", label: "전화번호" },
+        { value: "number", label: "숫자" },
+        { value: "password", label: "비밀번호" },
       ],
       required: false,
-      default: "text",
+      value: "text",
     },
     placeholder: {
-      type: "string",
-      name: "placeholder",
+      type: PROPERTY_TYPE_STRING,
+      label: "placeholder",
+      value: "",
       required: false,
     },
-    value: { type: "string", name: "기본값", required: false },
+    value: {
+      type: PROPERTY_TYPE_STRING,
+      label: "기본값",
+      value: "",
+      required: false,
+    },
   },
   select: {
     options: [],
@@ -95,8 +117,9 @@ const Components = {
   },
   checkbox: {
     value: {
-      type: "bool",
-      name: "체크 여부",
+      type: PROPERTY_TYPE_BOOLEAN,
+      label: "체크 여부",
+      value: false,
       required: false,
     },
   },

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -2,6 +2,7 @@ import {
   PROPERTY_TYPE_STRING,
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_TYPE_SELECT,
+  PROPERTY_OPTION_START_NUMBER,
 } from "../../../constants/calculetComponent";
 
 /**
@@ -62,6 +63,21 @@ const Option = {
 };
 
 /**
+ * 옵션이 있는 컴포넌트의 기본 옵션에 대한 속성 정보
+ */
+const DefaultOption = {
+  id: PROPERTY_OPTION_START_NUMBER,
+  value: {
+    ...Option.value,
+    disabled: true,
+  },
+  label: {
+    ...Option.label,
+    disabled: true,
+  },
+};
+
+/**
  * 컴포넌트 속성들에 대한 정보를 담은 객체
  */
 const Components = {
@@ -110,10 +126,10 @@ const Components = {
     },
   },
   select: {
-    options: [],
+    options: [DefaultOption],
   },
   multiSelect: {
-    options: [],
+    options: [DefaultOption],
   },
   checkbox: {
     value: {
@@ -124,7 +140,7 @@ const Components = {
     },
   },
   multiCheckbox: {
-    options: [],
+    options: [DefaultOption],
   },
 };
 

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -2,7 +2,7 @@
  * 컴포넌트들에 공통으로 쓰이는 속성
  * key : 속성 이름 (mui에서 쓰이는 속성 이름과 동일)
  * value :
- *   - type : string - textfield, bool - checkbox, select - select box
+ *   - type : string - text field, bool - checkbox, select - select box
  *   - name : 페이지에 표시되는 이름 (label)
  *   - required : 필수로 입력되어야 하는 속성인지
  *   - options : select box에 표시되는 옵션들

--- a/client/src/components/organisms/register-editor/ComponentOptions.js
+++ b/client/src/components/organisms/register-editor/ComponentOptions.js
@@ -142,6 +142,9 @@ const Components = {
   multiCheckbox: {
     options: [DefaultOption],
   },
+  radio: {
+    options: [DefaultOption],
+  },
 };
 
 export { Common, Option, Components };

--- a/client/src/components/organisms/register-editor/DatePickerComponent.js
+++ b/client/src/components/organisms/register-editor/DatePickerComponent.js
@@ -1,0 +1,16 @@
+import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+
+function DatePickerComponent(props) {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={["DatePicker"]}>
+        <DatePicker {...props} />
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+}
+
+export default DatePickerComponent;

--- a/client/src/components/organisms/register-editor/InputHelperComponent.js
+++ b/client/src/components/organisms/register-editor/InputHelperComponent.js
@@ -1,0 +1,48 @@
+import { Button, Typography } from "@mui/material";
+import { FlexBox } from "../common/FlexBox";
+
+/**
+ *
+ * @param {*} props 컴포넌트 속성 정보들
+ * label: 설명
+ * options: 각 버튼들에 대한 정보
+ *    - value: 버튼 변수명
+ *    - label: 버튼 값 (버튼 클릭 시, 복사될 값)
+ * @returns
+ */
+function InputHelperComponent(props) {
+  function OnClickButton(event) {
+    const target = document.getElementById(props.target);
+    if (target != null) {
+      target.value = event.target.innerText;
+    }
+  }
+  return (
+    <>
+      <Typography variant="caption">{props.label}</Typography>
+      <FlexBox
+        sx={{
+          width: "fit-content",
+          padding: "1rem",
+          gap: "0.5rem",
+          borderRadius: "0.25rem",
+          backgroundColor: "#E6EBF4",
+        }}
+        id={props.id}
+      >
+        {Object.entries(props.options).map(([id, option], index) => (
+          <Button
+            key={index}
+            id={option.value}
+            variant="contained"
+            onClick={OnClickButton}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </FlexBox>
+    </>
+  );
+}
+
+export default InputHelperComponent;

--- a/client/src/components/organisms/register-editor/InputHelperComponent.js
+++ b/client/src/components/organisms/register-editor/InputHelperComponent.js
@@ -32,6 +32,7 @@ function InputHelperComponent(props) {
       >
         {Object.entries(props.options).map(([id, option], index) => (
           <Button
+            sx={{ textTransform: "none" }}
             key={index}
             id={option.value}
             variant="contained"

--- a/client/src/components/organisms/register-editor/MultiCheckBoxComponent.js
+++ b/client/src/components/organisms/register-editor/MultiCheckBoxComponent.js
@@ -6,20 +6,20 @@ import {
   FormControl,
 } from "@mui/material";
 
-function MultiCheckboxComponent({ data }) {
+function MultiCheckboxComponent(props) {
   return (
     <FormControl component="fieldset" variant="standard">
-      <FormLabel component="legend">{data.label}</FormLabel>
+      <FormLabel component="legend">{props.label}</FormLabel>
       <FormGroup>
-        {Object.entries(data.options).map(([id, option], index) => (
+        {Object.entries(props.options).map(([id, option], index) => (
           <FormControlLabel
             key={index}
             control={
               <Checkbox
-                id={data.id}
-                onChange={data.onChange}
+                id={props.id}
+                onChange={props.onChange}
                 name={option.value}
-                checked={data.value[option.value]}
+                checked={props.value[option.value]}
               />
             }
             label={option.label}

--- a/client/src/components/organisms/register-editor/RadioComponent.js
+++ b/client/src/components/organisms/register-editor/RadioComponent.js
@@ -1,0 +1,27 @@
+import {
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  Radio,
+  FormControlLabel,
+} from "@mui/material";
+
+function RadioComponent(props) {
+  return (
+    <FormControl>
+      <FormLabel>{props.label}</FormLabel>
+      <RadioGroup {...props} name={props.id}>
+        {Object.entries(props.options).map(([id, option], index) => (
+          <FormControlLabel
+            key={index}
+            value={option.value}
+            control={<Radio />}
+            label={option.label}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+}
+
+export default RadioComponent;

--- a/client/src/components/organisms/register-editor/SelectComponent.js
+++ b/client/src/components/organisms/register-editor/SelectComponent.js
@@ -1,9 +1,9 @@
 import { Select, MenuItem } from "@mui/material";
 
-function SelectComponent({ data }) {
+function SelectComponent(props) {
   return (
-    <Select {...data} name={data.id}>
-      {Object.entries(data.options).map(([id, option], index) => (
+    <Select {...props} name={props.id}>
+      {Object.entries(props.options).map(([id, option], index) => (
         <MenuItem key={index} value={option.value}>
           {option.label}
         </MenuItem>

--- a/client/src/components/organisms/register-editor/Transformer.js
+++ b/client/src/components/organisms/register-editor/Transformer.js
@@ -5,6 +5,13 @@ import SelectComponent from "./SelectComponent";
 import CheckboxComponent from "./CheckboxComponent";
 import MultiCheckboxComponent from "./MultiCheckBoxComponent";
 import CopyButton from "./CopyButton";
+import {
+  TEXT_FIELD,
+  SELECT,
+  MULTI_SELECT,
+  CHECK_BOX,
+  MULTI_CHECK_BOX,
+} from "../../../constants/calculetComponent";
 
 /**
  * 사용자 입력 객체를 컴포넌트로 변환해주는 함수
@@ -23,13 +30,13 @@ function Transformer({ data, onChange, initInputs }) {
   let value = data.value;
   if (!value) {
     switch (data.componentType) {
-      case "multiSelect":
+      case MULTI_SELECT:
         value = [];
         break;
-      case "checkbox":
+      case CHECK_BOX:
         value = false;
         break;
-      case "multiCheckbox":
+      case MULTI_CHECK_BOX:
         value = {};
         for (const key in data.options) {
           value = {
@@ -69,17 +76,17 @@ function Transformer({ data, onChange, initInputs }) {
   // console.log("추가된 컴포넌트", properties);
 
   switch (data.componentType) {
-    case "textField":
+    case TEXT_FIELD:
       return <TextField {...properties} />;
-    case "select":
+    case SELECT:
       return <SelectComponent data={properties} />;
-    case "multiSelect":
+    case MULTI_SELECT:
       const newData = { ...properties, multiple: true };
       return <SelectComponent data={newData} />;
-    case "checkbox":
+    case CHECK_BOX:
       const { label: labelData, ...rest } = properties;
       return <CheckboxComponent data={rest} label={labelData} />;
-    case "multiCheckbox":
+    case MULTI_CHECK_BOX:
       return <MultiCheckboxComponent data={properties} />;
     default:
       return;

--- a/client/src/components/organisms/register-editor/Transformer.js
+++ b/client/src/components/organisms/register-editor/Transformer.js
@@ -1,10 +1,6 @@
 import React from "react";
 // import { useEffect } from "react";
 import { TextField } from "@mui/material";
-import SelectComponent from "./SelectComponent";
-import CheckboxComponent from "./CheckboxComponent";
-import MultiCheckboxComponent from "./MultiCheckBoxComponent";
-import CopyButton from "./CopyButton";
 import {
   TEXT_FIELD,
   SELECT,
@@ -15,11 +11,17 @@ import {
   INPUT_HELPER,
   CALCULET_BUTTON,
   TYPOGRAPHY,
+  // DATE_PICKER,
 } from "../../../constants/calculetComponent";
+import SelectComponent from "./SelectComponent";
+import CheckboxComponent from "./CheckboxComponent";
+import MultiCheckboxComponent from "./MultiCheckBoxComponent";
+import CopyButton from "./CopyButton";
 import RadioComponent from "./RadioComponent";
 import InputHelperComponent from "./InputHelperComponent";
 import CalculetButtonComponent from "./CalculetButtonComponent";
 import TypographyComponent from "./TypographyComponent";
+// import DatePickerComponent from "./DatePickerComponent";
 
 /**
  * 사용자 입력 객체를 컴포넌트로 변환해주는 함수
@@ -89,6 +91,8 @@ function Transformer({ data }) {
       return <TypographyComponent {...properties} />;
     case TEXT_FIELD:
       return <TextField {...properties} />;
+    // case DATE_PICKER:
+    //   return <DatePickerComponent {...properties} />;
     case SELECT:
       return <SelectComponent {...properties} />;
     case MULTI_SELECT:

--- a/client/src/components/organisms/register-editor/Transformer.js
+++ b/client/src/components/organisms/register-editor/Transformer.js
@@ -14,10 +14,12 @@ import {
   RADIO,
   INPUT_HELPER,
   CALCULET_BUTTON,
+  TYPOGRAPHY,
 } from "../../../constants/calculetComponent";
 import RadioComponent from "./RadioComponent";
 import InputHelperComponent from "./InputHelperComponent";
 import CalculetButtonComponent from "./CalculetButtonComponent";
+import TypographyComponent from "./TypographyComponent";
 
 /**
  * 사용자 입력 객체를 컴포넌트로 변환해주는 함수
@@ -83,6 +85,8 @@ function Transformer({ data }) {
   // console.log("추가된 컴포넌트", properties);
 
   switch (data.componentType) {
+    case TYPOGRAPHY:
+      return <TypographyComponent {...properties} />;
     case TEXT_FIELD:
       return <TextField {...properties} />;
     case SELECT:

--- a/client/src/components/organisms/register-editor/Transformer.js
+++ b/client/src/components/organisms/register-editor/Transformer.js
@@ -11,7 +11,9 @@ import {
   MULTI_SELECT,
   CHECK_BOX,
   MULTI_CHECK_BOX,
+  RADIO,
 } from "../../../constants/calculetComponent";
+import RadioComponent from "./RadioComponent";
 
 /**
  * 사용자 입력 객체를 컴포넌트로 변환해주는 함수
@@ -86,6 +88,8 @@ function Transformer({ data, onChange, initInputs }) {
       return <CheckboxComponent {...properties} />;
     case MULTI_CHECK_BOX:
       return <MultiCheckboxComponent {...properties} />;
+    case RADIO:
+      return <RadioComponent {...properties} />;
     default:
       return;
   }

--- a/client/src/components/organisms/register-editor/Transformer.js
+++ b/client/src/components/organisms/register-editor/Transformer.js
@@ -13,9 +13,11 @@ import {
   MULTI_CHECK_BOX,
   RADIO,
   INPUT_HELPER,
+  CALCULET_BUTTON,
 } from "../../../constants/calculetComponent";
 import RadioComponent from "./RadioComponent";
 import InputHelperComponent from "./InputHelperComponent";
+import CalculetButtonComponent from "./CalculetButtonComponent";
 
 /**
  * 사용자 입력 객체를 컴포넌트로 변환해주는 함수
@@ -95,6 +97,8 @@ function Transformer({ data }) {
       return <RadioComponent {...properties} />;
     case INPUT_HELPER:
       return <InputHelperComponent {...properties} />;
+    case CALCULET_BUTTON:
+      return <CalculetButtonComponent {...properties} />;
     default:
       return;
   }

--- a/client/src/components/organisms/register-editor/Transformer.js
+++ b/client/src/components/organisms/register-editor/Transformer.js
@@ -12,8 +12,10 @@ import {
   CHECK_BOX,
   MULTI_CHECK_BOX,
   RADIO,
+  INPUT_HELPER,
 } from "../../../constants/calculetComponent";
 import RadioComponent from "./RadioComponent";
+import InputHelperComponent from "./InputHelperComponent";
 
 /**
  * 사용자 입력 객체를 컴포넌트로 변환해주는 함수
@@ -90,6 +92,8 @@ function Transformer({ data, onChange, initInputs }) {
       return <MultiCheckboxComponent {...properties} />;
     case RADIO:
       return <RadioComponent {...properties} />;
+    case INPUT_HELPER:
+      return <InputHelperComponent {...properties} />;
     default:
       return;
   }

--- a/client/src/components/organisms/register-editor/Transformer.js
+++ b/client/src/components/organisms/register-editor/Transformer.js
@@ -79,15 +79,13 @@ function Transformer({ data, onChange, initInputs }) {
     case TEXT_FIELD:
       return <TextField {...properties} />;
     case SELECT:
-      return <SelectComponent data={properties} />;
+      return <SelectComponent {...properties} />;
     case MULTI_SELECT:
-      const newData = { ...properties, multiple: true };
-      return <SelectComponent data={newData} />;
+      return <SelectComponent {...properties} multiple={true} />;
     case CHECK_BOX:
-      const { label: labelData, ...rest } = properties;
-      return <CheckboxComponent data={rest} label={labelData} />;
+      return <CheckboxComponent {...properties} />;
     case MULTI_CHECK_BOX:
-      return <MultiCheckboxComponent data={properties} />;
+      return <MultiCheckboxComponent {...properties} />;
     default:
       return;
   }

--- a/client/src/components/organisms/register-editor/TypographyComponent.js
+++ b/client/src/components/organisms/register-editor/TypographyComponent.js
@@ -1,0 +1,8 @@
+import { Typography } from "@mui/material";
+
+function TypographyComponent(props) {
+  const { content, ...properties } = props;
+  return <Typography {...properties}>{content}</Typography>;
+}
+
+export default TypographyComponent;

--- a/client/src/constants/calculetComponent.js
+++ b/client/src/constants/calculetComponent.js
@@ -1,0 +1,27 @@
+const TYPOGRAPHY = "typography";
+const TEXT_FIELD = "textField";
+const FILE = "file";
+const DATE_PICKER = "datePicker";
+const ADDRESS = "address";
+const CHECK_BOX = "checkbox";
+const SELECT = "select";
+const RADIO = "radio";
+const MULTI_SELECT = "multiSelect";
+const MULTI_CHECK_BOX = "multiCheckbox";
+const INPUT_HELPER = "inputHelper";
+const CALCULET_BUTTON = "calculetButton";
+
+export {
+  TYPOGRAPHY,
+  TEXT_FIELD,
+  FILE,
+  DATE_PICKER,
+  ADDRESS,
+  CHECK_BOX,
+  SELECT,
+  RADIO,
+  MULTI_SELECT,
+  MULTI_CHECK_BOX,
+  INPUT_HELPER,
+  CALCULET_BUTTON,
+};

--- a/client/src/constants/calculetComponent.js
+++ b/client/src/constants/calculetComponent.js
@@ -16,6 +16,7 @@ const CALCULET_BUTTON = "calculetButton";
 const PROPERTY_TYPE_STRING = "string";
 const PROPERTY_TYPE_BOOLEAN = "bool";
 const PROPERTY_TYPE_SELECT = "select";
+const PROPERTY_TYPE_DATE = "date";
 
 // calculet component option start number
 const PROPERTY_OPTION_START_NUMBER = 0;
@@ -36,5 +37,6 @@ export {
   PROPERTY_TYPE_STRING,
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_TYPE_SELECT,
+  PROPERTY_TYPE_DATE,
   PROPERTY_OPTION_START_NUMBER,
 };

--- a/client/src/constants/calculetComponent.js
+++ b/client/src/constants/calculetComponent.js
@@ -17,6 +17,9 @@ const PROPERTY_TYPE_STRING = "string";
 const PROPERTY_TYPE_BOOLEAN = "bool";
 const PROPERTY_TYPE_SELECT = "select";
 
+// calculet component option start number
+const PROPERTY_OPTION_START_NUMBER = 0;
+
 export {
   TYPOGRAPHY,
   TEXT_FIELD,
@@ -33,4 +36,5 @@ export {
   PROPERTY_TYPE_STRING,
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_TYPE_SELECT,
+  PROPERTY_OPTION_START_NUMBER,
 };

--- a/client/src/constants/calculetComponent.js
+++ b/client/src/constants/calculetComponent.js
@@ -1,3 +1,4 @@
+// calculet component
 const TYPOGRAPHY = "typography";
 const TEXT_FIELD = "textField";
 const FILE = "file";
@@ -10,6 +11,11 @@ const MULTI_SELECT = "multiSelect";
 const MULTI_CHECK_BOX = "multiCheckbox";
 const INPUT_HELPER = "inputHelper";
 const CALCULET_BUTTON = "calculetButton";
+
+// calculet component option (property) type
+const PROPERTY_TYPE_STRING = "string";
+const PROPERTY_TYPE_BOOLEAN = "bool";
+const PROPERTY_TYPE_SELECT = "select";
 
 export {
   TYPOGRAPHY,
@@ -24,4 +30,7 @@ export {
   MULTI_CHECK_BOX,
   INPUT_HELPER,
   CALCULET_BUTTON,
+  PROPERTY_TYPE_STRING,
+  PROPERTY_TYPE_BOOLEAN,
+  PROPERTY_TYPE_SELECT,
 };

--- a/client/src/modules/calculetEditor.js
+++ b/client/src/modules/calculetEditor.js
@@ -14,6 +14,7 @@ import {
   MULTI_CHECK_BOX,
   PROPERTY_TYPE_STRING,
   PROPERTY_TYPE_BOOLEAN,
+  PROPERTY_OPTION_START_NUMBER,
 } from "../constants/calculetComponent";
 
 const CALCULET_EDITOR_COMPONENTS_APPEND =
@@ -79,7 +80,7 @@ function createNewComponent(data) {
     case MULTI_SELECT:
     case MULTI_CHECK_BOX:
       newComponent.options = {
-        "-1": {
+        [PROPERTY_OPTION_START_NUMBER]: {
           value: "default",
           label: "기본값",
         },

--- a/client/src/modules/calculetEditor.js
+++ b/client/src/modules/calculetEditor.js
@@ -8,6 +8,11 @@ import {
   Common,
   Components,
 } from "../components/organisms/register-editor/ComponentOptions";
+import {
+  SELECT,
+  MULTI_SELECT,
+  MULTI_CHECK_BOX,
+} from "../constants/calculetComponent";
 
 const CALCULET_EDITOR_COMPONENTS_APPEND =
   "calculetEditor/CALCULET_EDITOR_COMPONENTS_APPEND";
@@ -68,9 +73,9 @@ function createNewComponent(data) {
   );
 
   switch (data.componentType) {
-    case "select":
-    case "multiSelect":
-    case "multiCheckbox":
+    case SELECT:
+    case MULTI_SELECT:
+    case MULTI_CHECK_BOX:
       newComponent.options = {
         "-1": {
           value: "default",

--- a/client/src/modules/calculetEditor.js
+++ b/client/src/modules/calculetEditor.js
@@ -12,6 +12,7 @@ import {
   SELECT,
   MULTI_SELECT,
   MULTI_CHECK_BOX,
+  RADIO,
   PROPERTY_TYPE_STRING,
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_OPTION_START_NUMBER,
@@ -79,6 +80,7 @@ function createNewComponent(data) {
     case SELECT:
     case MULTI_SELECT:
     case MULTI_CHECK_BOX:
+    case RADIO:
       newComponent.options = {
         [PROPERTY_OPTION_START_NUMBER]: {
           value: "default",

--- a/client/src/modules/calculetEditor.js
+++ b/client/src/modules/calculetEditor.js
@@ -12,6 +12,8 @@ import {
   SELECT,
   MULTI_SELECT,
   MULTI_CHECK_BOX,
+  PROPERTY_TYPE_STRING,
+  PROPERTY_TYPE_BOOLEAN,
 } from "../constants/calculetComponent";
 
 const CALCULET_EDITOR_COMPONENTS_APPEND =
@@ -54,14 +56,14 @@ function createNewComponent(data) {
   const newComponent = { ...data };
   Object.entries({ ...Common, ...Components[data.componentType] }).map(
     ([key, value]) => {
-      if (value.default !== undefined) {
-        newComponent[key] = value.default;
+      if (value.value !== undefined) {
+        newComponent[key] = value.value;
       } else {
         switch (value.type) {
-          case "string":
+          case PROPERTY_TYPE_STRING:
             newComponent[key] = "";
             break;
-          case "bool":
+          case PROPERTY_TYPE_BOOLEAN:
             newComponent[key] = false;
             break;
           default:

--- a/client/src/modules/calculetEditor.js
+++ b/client/src/modules/calculetEditor.js
@@ -16,6 +16,7 @@ import {
   PROPERTY_TYPE_STRING,
   PROPERTY_TYPE_BOOLEAN,
   PROPERTY_OPTION_START_NUMBER,
+  INPUT_HELPER,
 } from "../constants/calculetComponent";
 
 const CALCULET_EDITOR_COMPONENTS_APPEND =
@@ -81,6 +82,7 @@ function createNewComponent(data) {
     case MULTI_SELECT:
     case MULTI_CHECK_BOX:
     case RADIO:
+    case INPUT_HELPER:
       newComponent.options = {
         [PROPERTY_OPTION_START_NUMBER]: {
           value: "default",


### PR DESCRIPTION
### 📌 작업 내용
- 컴포넌트 상수 처리
- options이 있는 컴포넌트들에 기본값 넣기 (기본값 옵션이 벌룬창 내에서도 보이도록)
- 컴포넌트 props 넘겨주는 방식 수정 (기존에 data 변수에 객체로 지정해서 받는 방식 대신, props 받도록)
- 남은 컴포넌트들 작업
  - radio
  - input helper (버튼 도우미)
  - 계산하기 버튼
  - typography
  - date picker (ing) - 라이브러리 설치과정에서 이슈 발생해서 우선 보류

### ✅ Check List

- FE
  - [x] warning 해결
  - [x] console 주석
